### PR TITLE
chore(deps): grupo minor/patch rebaseado + ignore de langchain (substitui #7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    # langchain/langchain-community são travados juntos: langchain==0.1.0 exige
+    # langchain-community>=0.0.9,<0.1. Bumps piecemeal (ex.: community 0.4.2)
+    # quebram a resolução do pip. O ecossistema LangChain deve subir de forma
+    # coordenada, não via grupo minor/patch — por isso é ignorado aqui.
+    ignore:
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-community"
     groups:
       # Agrupa patch/minor de todas as libs num só PR para reduzir ruído.
       python-minor-e-patch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,13 @@ src = ["app", "scripts", "tests"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "C4"]
 # Erros comuns em código legado do protótipo (ajustados de forma incremental)
-ignore = ["B008"]  # FastAPI usa chamadas em defaults (Depends(...))
+ignore = [
+    "B008",  # FastAPI usa chamadas em defaults (Depends(...))
+    # Novas regras do pyupgrade surgidas no ruff 0.15 sobre código pré-existente;
+    # não adotadas para não alterar comportamento/contrato (adoção incremental):
+    "UP042",  # (str, Enum) -> StrEnum muda semântica de str()/serialização dos enums
+    "UP041",  # asyncio.TimeoutError -> TimeoutError (alias); manter forma explícita
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["B011"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 # Web framework / API
 fastapi==0.139.0  # >=0.115.3 corrige CVE-2024-47874; >=0.130 exige starlette/pydantic abaixo
-uvicorn[standard]==0.24.0
+uvicorn[standard]==0.50.2
 starlette==1.3.1  # >=1.0.1 corrige CVE-2026-48710 (BadHost: bypass de auth via Host header); pin explícito
 pydantic==2.13.4  # exigido por fastapi>=0.130 (>=2.9.0)
 pydantic-settings==2.14.2  # acompanha o bump de pydantic (exige pydantic>=2.7.0)
@@ -12,42 +12,42 @@ python-multipart==0.0.32  # >=0.0.7 corrige CVE-2024-24762 (ReDoS no parsing de 
 
 # Plataforma: banco relacional (SQLAlchemy 2.0 async + Alembic)
 # SQLite (aiosqlite) em dev; Postgres (asyncpg) em produção / Cloud SQL.
-SQLAlchemy==2.0.25
-alembic==1.13.1
-aiosqlite==0.19.0
-asyncpg==0.29.0
-greenlet==3.0.3
+SQLAlchemy==2.0.51
+alembic==1.18.5
+aiosqlite==0.22.1
+asyncpg==0.31.0
+greenlet==3.5.3
 
 # Segurança: hash de senha (Argon2), JWT de sessão do portal
 passlib[argon2]==1.7.4
 argon2-cffi==23.1.0
-PyJWT==2.8.0
-email-validator==2.1.0
+PyJWT==2.13.0
+email-validator==2.3.0
 
 # E-mail (verificação de conta) — SMTP async; backend console em dev
 aiosmtplib==5.1.2
 
 # Rate limiting
-slowapi==0.1.9
+slowapi==0.1.10
 
 # Superfícies visuais (SSR: landing + portal + docs)
-Jinja2==3.1.3
+Jinja2==3.1.6
 
 # Vetores / IA (RAG) — camada aumentada e opcional
 chromadb==0.4.18
 langchain==0.1.0
-langchain-community==0.0.10
+langchain-community==0.0.10  # travado por langchain==0.1.0 (exige >=0.0.9,<0.1); Dependabot ignora este pacote
 sentence-transformers==5.6.0  # 2.2.2 quebra com huggingface_hub>=0.26 (cached_download removido)
 openai==2.44.0
-google-generativeai==0.3.2
+google-generativeai==0.8.6
 
 # Processamento de dados / extração determinística de PDF
 pandas==2.1.4
 numpy==1.24.3
-requests==2.31.0
-beautifulsoup4==4.12.2
+requests==2.34.2
+beautifulsoup4==4.15.0
 lxml==4.9.3
-pdfplumber==0.10.3
+pdfplumber==0.11.10
 PyPDF2==3.0.1
 pypdf==6.14.2
 pikepdf==10.9.1
@@ -56,18 +56,18 @@ pikepdf==10.9.1
 pytest==7.4.3
 pytest-cov==4.1.0
 pytest-asyncio==0.21.1
-httpx==0.25.2
+httpx==0.28.1
 
 # Qualidade de código
-ruff==0.1.6
+ruff==0.15.20
 black==23.11.0
 mypy==2.1.0
 pre-commit==4.6.0
 
 # Documentação
-mkdocs==1.5.3
-mkdocs-material==9.4.8
+mkdocs==1.6.1
+mkdocs-material==9.7.6
 
 # Produção
 gunicorn==21.2.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2


### PR DESCRIPTION
## Contexto
Substitui o PR #7 (grupo `python-minor-e-patch` do Dependabot), que ficou **quebrado e conflitante**:

1. **Falha de resolução**: o grupo subia `langchain-community` para `0.4.2`, incompatível com `langchain==0.1.0` (exige `>=0.0.9,<0.1`) → `ResolutionImpossible` no `pip install` (CI vermelho em build e testes).
2. **Reversão de majors**: como a branch nasceu de um `main` antigo, ela **revertia** `openai==2.44.0` (#9) e `aiosmtplib==5.1.2` (#8) já mesclados.
3. O Dependabot parou de rebasear a branch após edição manual.

## O que este PR faz
- Aplica os **19 bumps minor/patch** do grupo sobre o `main` atual (uvicorn, SQLAlchemy, alembic, aiosqlite, asyncpg, greenlet, PyJWT, email-validator, slowapi, Jinja2, google-generativeai, requests, beautifulsoup4, pdfplumber, httpx, ruff, mkdocs, mkdocs-material, python-dotenv).
- Mantém `langchain-community==0.0.10` (travado pelo core do RAG).
- Adiciona `ignore` de `langchain`/`langchain-community` no `dependabot.yml` para o ecossistema LangChain subir de forma coordenada, não piecemeal (evita recorrência do conflito).

## Validação
- `pip install --dry-run -r requirements.txt` resolve sem conflitos.
- Gates da Constituição (Princípio III): CI (testes + cobertura ≥ 80% + ruff/black + build Docker) precisa ficar verde antes do merge.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)