### PR TITLE
feat(portal): painel de BI de uso + rastreio de sucesso + gestão de senha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ versão referida abaixo é a da aplicação (campo `version` do app FastAPI); o
 contrato público da API permanece em `/api/v1` e **não** sofre quebra dentro da
 versão maior (Princípio I da [Constituição](.specify/memory/constitution.md)).
 
+## [Não lançado]
+
+### Adicionado
+
+- **Painel de BI de uso** no portal (`/portal/dashboard`): série diária dos
+  últimos 30 dias (chamadas totais vs. bem-sucedidas) renderizada como gráfico de
+  área **SSR determinístico** (SVG server-side, sem dependência de JS/CDN;
+  degrada para tabela acessível — Princípio VII), mais KPIs de total de
+  requisições e variação vs. período anterior, taxa de sucesso, uso de IA e keys
+  ativas. Novo endpoint `GET /api/v1/usage/analytics` (`AccountAnalyticsResponse`).
+- **Rastreio de desfecho das chamadas de API** para a taxa de sucesso: coluna
+  aditiva `usage_records.error_count` (migração `0004`) e `UsageOutcomeMiddleware`
+  que contabiliza requisições com desfecho de erro (>= 400) por key/bucket/dia,
+  sem tocar o caminho quente das bem-sucedidas.
+- **Gestão de senha** no portal e na API v1:
+  - Trocar senha autenticado — `POST /api/v1/auth/change-password` e
+    `/portal/account/password`.
+  - Recuperação por e-mail (fluxo "esqueci a senha") com token de uso único —
+    `POST /api/v1/auth/forgot-password`, `POST /api/v1/auth/reset-password` e as
+    páginas `/portal/forgot-password` / `/portal/reset-password`. Nova tabela
+    `password_reset_tokens` (migração `0005`); resposta anti-enumeração
+    (Princípio V).
+
+### Alterado
+
+- Painel do portal redesenhado (shell com sidebar, cartões de KPI, tabela de
+  keys refinada e pílulas de status), fiel ao design system por tokens (tema
+  claro/escuro automático).
+- Snapshots de OpenAPI (contrato e release `v1/1.3.0`) recongelados para incluir
+  os novos caminhos retrocompatíveis sob `/api/v1` (sem quebra — Princípio I).
+
 ## [1.3.0] - 2026-07-07
 
 ### Adicionado

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Body, Response, status
 from app.core.config import settings
 from app.core.deps import (
     CurrentAccount,
+    ForgotRateLimited,
     LoginRateLimited,
     SessionDep,
     SignupRateLimited,
@@ -22,8 +23,12 @@ from app.core.deps import (
 from app.models.bncc import ErrorResponse
 from app.models.platform import (
     AccountMe,
+    ChangePasswordRequest,
+    ForgotPasswordRequest,
     LoginRequest,
     LoginResponse,
+    MessageResponse,
+    ResetPasswordRequest,
     SignupRequest,
     SignupResponse,
     VerifyEmailRequest,
@@ -209,3 +214,117 @@ async def me(account: CurrentAccount) -> AccountMe:
         email=account.email,
         email_verified=account.email_verified,
     )
+
+
+@router.post(
+    "/change-password",
+    response_model=MessageResponse,
+    summary="Trocar a senha da conta autenticada",
+    response_description="Confirmação de que a senha foi alterada.",
+    description=(
+        "Troca a senha da conta associada à sessão atual, exigindo a senha atual. "
+        "A nova senha deve seguir a política (mín. 10 caracteres, com letras e "
+        "números). Contas criadas apenas por login social não possuem senha atual — "
+        "use o fluxo de redefinição para definir uma."
+    ),
+    responses={
+        400: {
+            "model": ErrorResponse,
+            "description": "Senha atual incorreta ou nova senha inválida.",
+        },
+        401: {"model": ErrorResponse, "description": "Sessão ausente, inválida ou expirada."},
+    },
+)
+async def change_password(
+    payload: Annotated[
+        ChangePasswordRequest,
+        Body(
+            openapi_examples={
+                "padrao": {
+                    "summary": "Troca de senha",
+                    "value": {
+                        "current_password": _EXAMPLE_PW,  # pragma: allowlist secret
+                        "new_password": "NovaSenha456",  # pragma: allowlist secret
+                    },
+                },
+            },
+        ),
+    ],
+    account: CurrentAccount,
+    session: SessionDep,
+) -> MessageResponse:
+    await account_service.change_password(
+        session, account, payload.current_password, payload.new_password
+    )
+    return MessageResponse(detail="Senha alterada com sucesso.")
+
+
+@router.post(
+    "/forgot-password",
+    response_model=MessageResponse,
+    summary="Solicitar redefinição de senha",
+    response_description="Resposta neutra: sempre a mesma, exista ou não a conta.",
+    description=(
+        "Dispara um e-mail com um link de redefinição de senha de uso único, quando "
+        "existe uma conta para o e-mail informado. Para preservar a privacidade "
+        "(anti-enumeração — Princípio V), a resposta é idêntica exista ou não a conta."
+    ),
+    responses={
+        429: {"model": ErrorResponse, "description": "Muitas solicitações deste IP."},
+    },
+)
+async def forgot_password(
+    payload: Annotated[
+        ForgotPasswordRequest,
+        Body(
+            openapi_examples={
+                "padrao": {"summary": "Pedido de reset", "value": {"email": "dev@example.com"}},
+            },
+        ),
+    ],
+    session: SessionDep,
+    _rate_limit: ForgotRateLimited,
+) -> MessageResponse:
+    await account_service.request_password_reset(session, payload.email)
+    return MessageResponse(
+        detail="Se houver uma conta para este e-mail, enviamos um link de redefinição."
+    )
+
+
+@router.post(
+    "/reset-password",
+    response_model=MessageResponse,
+    summary="Redefinir a senha com o token do e-mail",
+    response_description="Confirmação de que a senha foi redefinida.",
+    description=(
+        "Consome o token de uso único enviado por e-mail e grava a nova senha "
+        "(seguindo a política). Possuir o link comprova controle do e-mail, então a "
+        "conta é marcada como verificada."
+    ),
+    responses={
+        400: {
+            "model": ErrorResponse,
+            "description": "Token inválido ou nova senha fora da política.",
+        },
+        410: {"model": ErrorResponse, "description": "Token expirado ou já utilizado."},
+    },
+)
+async def reset_password(
+    payload: Annotated[
+        ResetPasswordRequest,
+        Body(
+            openapi_examples={
+                "padrao": {
+                    "summary": "Redefinição",
+                    "value": {
+                        "token": "token-recebido-por-email",
+                        "new_password": "NovaSenha456",  # pragma: allowlist secret
+                    },
+                },
+            },
+        ),
+    ],
+    session: SessionDep,
+) -> MessageResponse:
+    await account_service.reset_password(session, payload.token, payload.new_password)
+    return MessageResponse(detail="Senha redefinida com sucesso. Faça login para continuar.")

--- a/app/api/v1/endpoints/usage.py
+++ b/app/api/v1/endpoints/usage.py
@@ -12,7 +12,11 @@ from fastapi import APIRouter, Path
 
 from app.core.deps import CurrentAccount, SessionDep
 from app.models.bncc import ErrorResponse
-from app.models.platform import AccountUsageResponse, KeyUsageResponse
+from app.models.platform import (
+    AccountAnalyticsResponse,
+    AccountUsageResponse,
+    KeyUsageResponse,
+)
 from app.services import apikey_service, usage_service
 
 router = APIRouter()
@@ -65,3 +69,30 @@ async def key_usage(
 )
 async def account_usage(account: CurrentAccount, session: SessionDep) -> AccountUsageResponse:
     return await usage_service.account_usage(session, account.id)
+
+
+@router.get(
+    "/usage/analytics",
+    response_model=AccountAnalyticsResponse,
+    tags=["Uso"],
+    summary="Analytics de uso da conta (série diária + KPIs)",
+    response_description=(
+        "Série diária dos últimos 30 dias (total vs. bem-sucedidas) e KPIs "
+        "agregados: total de requisições e variação, taxa de sucesso, uso de IA, "
+        "keys ativas."
+    ),
+    description=(
+        "Retorna o BI de uso da conta autenticada: uma série diária dos últimos 30 "
+        "dias (chamadas totais vs. bem-sucedidas) e indicadores agregados para o "
+        "painel do portal (total de requisições com variação vs. período anterior, "
+        "taxa de sucesso, chamadas de IA e determinísticas, keys ativas e novas). "
+        "Exige sessão do portal."
+    ),
+    responses={
+        401: {"model": ErrorResponse, "description": "Sessão ausente, inválida ou expirada."},
+    },
+)
+async def account_analytics(
+    account: CurrentAccount, session: SessionDep
+) -> AccountAnalyticsResponse:
+    return await usage_service.account_analytics(session, account.id)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -63,6 +63,10 @@ class Settings(BaseSettings):
     EMAIL_FROM: str = Field(default="no-reply@bncc.example.com")
     EMAIL_VERIFICATION_BASE_URL: str = Field(default="http://localhost:8000/portal/verify-email")
     EMAIL_TOKEN_EXPIRE_MINUTES: int = Field(default=1440)
+    # Redefinição de senha ("esqueci a senha"): página do portal que consome o token.
+    PASSWORD_RESET_BASE_URL: str = Field(default="http://localhost:8000/portal/reset-password")
+    # Token de reset é sensível (troca de credencial) → janela curta.
+    PASSWORD_RESET_TOKEN_EXPIRE_MINUTES: int = Field(default=60)
     SMTP_HOST: str = Field(default="")
     SMTP_PORT: int = Field(default=587)
     SMTP_USERNAME: str = Field(default="")
@@ -82,6 +86,8 @@ class Settings(BaseSettings):
     RATE_LIMIT_SIGNUP_PER_MIN: int = Field(default=5)
     RATE_LIMIT_VERIFY_PER_MIN: int = Field(default=30)
     RATE_LIMIT_OAUTH_PER_MIN: int = Field(default=10)
+    # "Esqueci a senha": dispara e-mail com token → coíbe spam/enumeração por IP.
+    RATE_LIMIT_FORGOT_PER_MIN: int = Field(default=5)
 
     # --- Login social (OAuth 2.0) — opcional; desabilita se não configurado ---
     # Secrets carregados do ambiente (Princípio V). Ambos os campos de um provedor

--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -53,6 +53,9 @@ verify_ip_limiter = SlidingWindowLimiter(
 oauth_ip_limiter = SlidingWindowLimiter(
     max_requests=settings.RATE_LIMIT_OAUTH_PER_MIN, window_seconds=60
 )
+forgot_ip_limiter = SlidingWindowLimiter(
+    max_requests=settings.RATE_LIMIT_FORGOT_PER_MIN, window_seconds=60
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -187,7 +190,22 @@ def _enforce(limiter: SlidingWindowLimiter, api_key: ApiKey, bucket: str) -> Non
         )
 
 
-async def rate_limit_deterministic(api_key: ApiKeyAuth, session: SessionDep) -> ApiKey:
+def _mark_usage(request: Request | None, api_key_id: str, bucket: str) -> None:
+    """Sinaliza no ``request.state`` a key/bucket cujo ``count`` já foi contabilizado.
+
+    O ``UsageOutcomeMiddleware`` lê estes campos após a resposta e, se o status for
+    de erro (>= 400), incrementa ``error_count`` da mesma linha diária. Só marcamos
+    depois do registro do total — assim taxa de sucesso e total ficam consistentes,
+    e requisições barradas por 429 (sem total) não entram na conta de erros.
+    """
+    if request is not None:
+        request.state.usage_api_key_id = api_key_id
+        request.state.usage_bucket = bucket
+
+
+async def rate_limit_deterministic(
+    api_key: ApiKeyAuth, session: SessionDep, request: Request = None  # type: ignore[assignment]
+) -> ApiKey:
     """Cota determinística: 60/min + burst 10 (FR-010).
 
     Além do enforcement em memória (janela/min), contabiliza a chamada no bucket
@@ -200,13 +218,16 @@ async def rate_limit_deterministic(api_key: ApiKeyAuth, session: SessionDep) -> 
         from app.services.usage_service import record_deterministic
 
         await record_deterministic(session, api_key.id)
+        _mark_usage(request, api_key.id, "deterministic")
     except ImportError:
         # usage_service ainda não implementado (antes de US2) — janela/min já protege.
         pass
     return api_key
 
 
-async def rate_limit_ai(api_key: ApiKeyAuth, session: SessionDep) -> ApiKey:
+async def rate_limit_ai(
+    api_key: ApiKeyAuth, session: SessionDep, request: Request = None  # type: ignore[assignment]
+) -> ApiKey:
     """
     Cota de IA: 20/min (in-process) + teto diário de 500/dia durável (FR-010a).
 
@@ -217,6 +238,7 @@ async def rate_limit_ai(api_key: ApiKeyAuth, session: SessionDep) -> ApiKey:
         from app.services.usage_service import check_and_record_daily_ai
 
         await check_and_record_daily_ai(session, api_key.id)
+        _mark_usage(request, api_key.id, "ai")
     except ImportError:
         # usage_service ainda não implementado (antes de US2) — janela/min já protege.
         pass
@@ -264,10 +286,16 @@ async def rate_limit_oauth_ip(request: Request) -> None:
     _enforce_ip(oauth_ip_limiter, "oauth-ip", request)
 
 
+async def rate_limit_forgot_ip(request: Request) -> None:
+    """Cota por IP para "esqueci a senha" (coíbe spam de e-mail e enumeração)."""
+    _enforce_ip(forgot_ip_limiter, "forgot-ip", request)
+
+
 LoginRateLimited = Annotated[None, Depends(rate_limit_login_ip)]
 SignupRateLimited = Annotated[None, Depends(rate_limit_signup_ip)]
 VerifyRateLimited = Annotated[None, Depends(rate_limit_verify_ip)]
 OAuthRateLimited = Annotated[None, Depends(rate_limit_oauth_ip)]
+ForgotRateLimited = Annotated[None, Depends(rate_limit_forgot_ip)]
 
 
 # --------------------------------------------------------------------------- #

--- a/app/db/tables.py
+++ b/app/db/tables.py
@@ -62,6 +62,9 @@ class DeveloperAccount(Base):
     verification_tokens: Mapped[list[EmailVerificationToken]] = relationship(
         back_populates="account", cascade="all, delete-orphan"
     )
+    reset_tokens: Mapped[list[PasswordResetToken]] = relationship(
+        back_populates="account", cascade="all, delete-orphan"
+    )
     onboarding: Mapped[OnboardingProfile | None] = relationship(
         back_populates="account", cascade="all, delete-orphan", uselist=False
     )
@@ -175,6 +178,33 @@ class UsageRecord(Base):
     )
     bucket: Mapped[UsageBucket] = mapped_column(Enum(UsageBucket), nullable=False)
     window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # ``count`` é o total de chamadas autorizadas do dia (passaram no rate limit),
+    # independentemente do desfecho; ``error_count`` é o subconjunto que terminou
+    # em erro (>= 400). Assim taxa de sucesso = (count - error_count) / count sem
+    # tocar a UniqueConstraint (aditivo, migração 0004). Ver usage_service.
     count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    error_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
     api_key: Mapped[ApiKey] = relationship(back_populates="usage_records")
+
+
+class PasswordResetToken(Base):
+    """Token de uso único para redefinição de senha (fluxo "esqueci a senha").
+
+    Mesma disciplina do ``EmailVerificationToken``: só o hash SHA-256 é persistido,
+    expira e é invalidado após o uso. Anti-enumeração: solicitar reset para um
+    e-mail inexistente não cria registro nem revela a ausência.
+    """
+
+    __tablename__ = "password_reset_tokens"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("developer_accounts.id", ondelete="CASCADE"), index=True
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+
+    account: Mapped[DeveloperAccount] = relationship(back_populates="reset_tokens")

--- a/app/main.py
+++ b/app/main.py
@@ -162,6 +162,53 @@ class SecurityHeadersMiddleware:
 app.add_middleware(SecurityHeadersMiddleware)
 
 
+class UsageOutcomeMiddleware:
+    """Registra o desfecho (sucesso/erro) das chamadas de API autenticadas por key.
+
+    As dependências de rate limit já contabilizam o **total** por dia e marcam em
+    ``request.state`` (via ``scope["state"]``) a key/bucket da requisição. Aqui, após
+    a resposta, se o status for de erro (>= 400) incrementamos ``error_count`` da
+    mesma linha diária — habilitando a taxa de sucesso do painel sem alterar o
+    caminho quente das requisições bem-sucedidas. Nunca quebra a resposta."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        status_code = {"code": 200}
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                status_code["code"] = message["status"]
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+        if status_code["code"] < 400:
+            return
+        state = scope.get("state") or {}
+        api_key_id = state.get("usage_api_key_id")
+        bucket_name = state.get("usage_bucket")
+        if not api_key_id or not bucket_name:
+            return
+        try:
+            from app.db.base import async_session_factory
+            from app.db.tables import UsageBucket
+            from app.services.usage_service import record_error
+
+            async with async_session_factory() as session:
+                await record_error(session, api_key_id, UsageBucket(bucket_name))
+        except Exception:  # nunca deixa a contabilização derrubar a resposta
+            logger.debug("Falha ao registrar desfecho de erro de uso", exc_info=True)
+
+
+app.add_middleware(UsageOutcomeMiddleware)
+
+
 app.include_router(api_router, prefix="/api/v1")
 # Infra de documentação versionada (/api/versions, /api/{slug}/openapi.json,
 # /api/{slug}/releases/{release}/openapi.json). `/api/v1/openapi.json` continua

--- a/app/models/platform.py
+++ b/app/models/platform.py
@@ -8,7 +8,7 @@ Segredos (hash de senha/key/token) nunca aparecem em nenhum schema de saída.
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
@@ -68,6 +68,43 @@ class AccountMe(BaseModel):
 
 
 # --------------------------------------------------------------------------- #
+# Gestão de senha (troca logada + "esqueci a senha")
+# --------------------------------------------------------------------------- #
+class ChangePasswordRequest(BaseModel):
+    current_password: str = Field(..., description="Senha atual da conta")
+    new_password: str = Field(
+        ..., description="Nova senha: mín. 10 caracteres, com letras e números"
+    )
+
+    @field_validator("new_password")
+    @classmethod
+    def _password_policy(cls, v: str) -> str:
+        return _validate_password_policy(v)
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str = Field(..., min_length=8)
+    new_password: str = Field(
+        ..., description="Nova senha: mín. 10 caracteres, com letras e números"
+    )
+
+    @field_validator("new_password")
+    @classmethod
+    def _password_policy(cls, v: str) -> str:
+        return _validate_password_policy(v)
+
+
+class MessageResponse(BaseModel):
+    """Resposta neutra e genérica (usada em fluxos anti-enumeração)."""
+
+    detail: str
+
+
+# --------------------------------------------------------------------------- #
 # API keys
 # --------------------------------------------------------------------------- #
 class CreateApiKeyRequest(BaseModel):
@@ -113,3 +150,34 @@ class AccountUsageResponse(BaseModel):
     total_keys: int
     deterministic_used_today: int
     ai_used_today: int
+
+
+class UsageDailyPoint(BaseModel):
+    """Um ponto da série diária do painel (um dia do calendário UTC)."""
+
+    date: date
+    total: int = Field(..., description="Chamadas autorizadas no dia (qualquer desfecho)")
+    successful: int = Field(..., description="Chamadas com desfecho de sucesso (< 400)")
+    failed: int = Field(..., description="Chamadas com desfecho de erro (>= 400)")
+
+
+class AccountAnalyticsResponse(BaseModel):
+    """BI de uso da conta: série diária + KPIs agregados da janela (30 dias)."""
+
+    account_id: str
+    window_days: int
+    series: list[UsageDailyPoint]
+    total_requests: int
+    successful_requests: int
+    failed_requests: int
+    success_rate: float | None = Field(
+        None, description="successful/total na janela; nulo quando não houve tráfego"
+    )
+    total_requests_prev: int = Field(..., description="Total da janela anterior (para o delta)")
+    total_requests_delta_pct: float | None = Field(
+        None, description="Variação % vs. janela anterior; nulo quando a anterior foi zero"
+    )
+    ai_requests: int = Field(..., description="Chamadas de IA na janela")
+    deterministic_requests: int = Field(..., description="Chamadas determinísticas na janela")
+    active_keys: int
+    new_keys_last_7d: int = Field(..., description="Keys ativas criadas nos últimos 7 dias")

--- a/app/services/account_service.py
+++ b/app/services/account_service.py
@@ -23,7 +23,7 @@ from app.core.security import (
     hash_verification_token,
     verify_password,
 )
-from app.db.tables import DeveloperAccount, EmailVerificationToken
+from app.db.tables import DeveloperAccount, EmailVerificationToken, PasswordResetToken
 from app.services import email_service
 
 # Mensagens neutras (não revelam se o e-mail existe / qual credencial falhou).
@@ -31,6 +31,9 @@ _SIGNUP_CONFLICT = "Não foi possível concluir o cadastro."
 _LOGIN_FAILED = "Credenciais inválidas ou e-mail não verificado."
 _TOKEN_INVALID = "Token de verificação inválido."
 _TOKEN_EXPIRED = "Token de verificação expirado ou já utilizado."
+_CURRENT_PASSWORD_INVALID = "Senha atual incorreta."  # pragma: allowlist secret
+_RESET_TOKEN_INVALID = "Link de redefinição inválido."
+_RESET_TOKEN_EXPIRED = "Link de redefinição expirado ou já utilizado."
 
 # Hash Argon2 fixo (senha nunca usada por conta real) para gastar o mesmo tempo
 # de verificação quando a conta não existe — sem isto, `verify_password` só
@@ -159,3 +162,83 @@ async def login(
         email=account.email,
         expires_minutes=expires_minutes,
     )
+
+
+# --------------------------------------------------------------------------- #
+# Gestão de senha
+# --------------------------------------------------------------------------- #
+async def change_password(
+    session: AsyncSession,
+    account: DeveloperAccount,
+    current_password: str,
+    new_password: str,
+) -> None:
+    """Troca a senha de uma conta autenticada, exigindo a senha atual.
+
+    Contas só-social (``password_hash`` NULL) não têm senha atual válida: a
+    verificação falha e devem usar o fluxo de redefinição para **definir** uma.
+    """
+    hash_to_check = account.password_hash or _DUMMY_PASSWORD_HASH
+    if not verify_password(current_password, hash_to_check) or not account.password_hash:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=_CURRENT_PASSWORD_INVALID
+        )
+    account.password_hash = hash_password(new_password)
+    await session.commit()
+
+
+async def request_password_reset(session: AsyncSession, email: str) -> str | None:
+    """Emite (e envia) um token de redefinição de senha de uso único.
+
+    **Anti-enumeração:** para e-mail inexistente não cria registro nem envia nada,
+    e o chamador sempre responde de forma idêntica. Retorna o token em claro apenas
+    quando emitido (para o backend de console em dev/testes); nunca é persistido em
+    claro. Funciona também para contas só-social — permite *definir* uma senha.
+    """
+    normalized = _normalize_email(email)
+    result = await session.execute(
+        select(DeveloperAccount).where(DeveloperAccount.email == normalized)
+    )
+    account = result.scalar_one_or_none()
+    if account is None:
+        return None
+
+    token, token_hash = generate_verification_token()
+    reset = PasswordResetToken(
+        account_id=account.id,
+        token_hash=token_hash,
+        expires_at=_now() + timedelta(minutes=settings.PASSWORD_RESET_TOKEN_EXPIRE_MINUTES),
+    )
+    session.add(reset)
+    await session.commit()
+
+    await email_service.send_password_reset_email(account.email, token)
+    return token
+
+
+async def reset_password(session: AsyncSession, token: str, new_password: str) -> DeveloperAccount:
+    """Consome o token de redefinição e grava a nova senha.
+
+    Possuir o link prova controle da caixa de e-mail, então a conta é marcada como
+    verificada (mesma semântica da verificação de e-mail)."""
+    token_hash = hash_verification_token(token)
+    result = await session.execute(
+        select(PasswordResetToken).where(PasswordResetToken.token_hash == token_hash)
+    )
+    record = result.scalar_one_or_none()
+
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_RESET_TOKEN_INVALID)
+    if record.used_at is not None or _as_aware(record.expires_at) <= _now():
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail=_RESET_TOKEN_EXPIRED)
+
+    account = await session.get(DeveloperAccount, record.account_id)
+    if account is None:  # integridade referencial — não deveria ocorrer
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_RESET_TOKEN_INVALID)
+
+    record.used_at = _now()
+    account.password_hash = hash_password(new_password)
+    account.email_verified = True
+    await session.commit()
+    await session.refresh(account)
+    return account

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -18,10 +18,17 @@ from app.core.config import settings
 logger = logging.getLogger("bncc.email")
 
 
-def _verification_link(token: str) -> str:
-    base = settings.EMAIL_VERIFICATION_BASE_URL
+def _link_with_token(base: str, token: str) -> str:
     sep = "&" if "?" in base else "?"
     return f"{base}{sep}token={token}"
+
+
+def _verification_link(token: str) -> str:
+    return _link_with_token(settings.EMAIL_VERIFICATION_BASE_URL, token)
+
+
+def _reset_link(token: str) -> str:
+    return _link_with_token(settings.PASSWORD_RESET_BASE_URL, token)
 
 
 async def send_verification_email(email: str, token: str) -> None:
@@ -37,8 +44,35 @@ async def send_verification_email(email: str, token: str) -> None:
     logger.info("Verificação de e-mail para %s: %s", email, link)
 
 
-async def _send_smtp(email: str, link: str) -> None:
-    """Envia o e-mail de verificação por SMTP assíncrono (produção)."""
+async def send_password_reset_email(email: str, token: str) -> None:
+    """Envia (ou registra, em console) o e-mail de redefinição de senha."""
+    link = _reset_link(token)
+    backend = settings.EMAIL_BACKEND.strip().lower()
+
+    if backend == "smtp":
+        await _send_smtp(
+            email,
+            link,
+            subject="Redefinição de senha — BNCC API",
+            body=(
+                "Recebemos um pedido para redefinir a senha da sua conta na BNCC API.\n\n"
+                "Crie uma nova senha pelo link abaixo (expira em breve):\n\n"
+                f"{link}\n\n"
+                "Se você não solicitou, ignore esta mensagem — sua senha continua a mesma."
+            ),
+        )
+        return
+
+    logger.info("Redefinição de senha para %s: %s", email, link)
+
+
+async def _send_smtp(
+    email: str,
+    link: str,
+    subject: str = "Confirme seu e-mail — BNCC API",
+    body: str | None = None,
+) -> None:
+    """Envia um e-mail transacional por SMTP assíncrono (produção)."""
     from email.message import EmailMessage
 
     import aiosmtplib
@@ -46,12 +80,16 @@ async def _send_smtp(email: str, link: str) -> None:
     message = EmailMessage()
     message["From"] = settings.EMAIL_FROM
     message["To"] = email
-    message["Subject"] = "Confirme seu e-mail — BNCC API"
+    message["Subject"] = subject
     message.set_content(
-        "Bem-vindo(a) à BNCC API.\n\n"
-        "Confirme seu e-mail para liberar a geração de API keys:\n\n"
-        f"{link}\n\n"
-        "Se você não solicitou este cadastro, ignore esta mensagem."
+        body
+        if body is not None
+        else (
+            "Bem-vindo(a) à BNCC API.\n\n"
+            "Confirme seu e-mail para liberar a geração de API keys:\n\n"
+            f"{link}\n\n"
+            "Se você não solicitou este cadastro, ignore esta mensagem."
+        )
     )
 
     await aiosmtplib.send(

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -13,7 +13,7 @@ Métricas expostas por key e agregadas por conta alimentam o painel do portal.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, select
@@ -21,12 +21,17 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.db.tables import ApiKey, UsageBucket, UsageRecord
+from app.db.tables import ApiKey, ApiKeyStatus, UsageBucket, UsageRecord
 from app.models.platform import (
+    AccountAnalyticsResponse,
     AccountUsageResponse,
     BucketUsage,
     KeyUsageResponse,
+    UsageDailyPoint,
 )
+
+# Janela padrão do painel de BI (últimos N dias, inclusive hoje).
+ANALYTICS_WINDOW_DAYS = 30
 
 
 def _now() -> datetime:
@@ -127,6 +132,53 @@ async def record_deterministic(session: AsyncSession, api_key_id: str) -> None:
     await _record(session, api_key_id, UsageBucket.deterministic)
 
 
+async def record_error(session: AsyncSession, api_key_id: str, bucket: UsageBucket) -> None:
+    """Marca uma chamada do dia como malsucedida (desfecho >= 400).
+
+    Incrementa ``error_count`` na linha diária já criada pelo registro do total
+    (o middleware só chama isto para requisições que passaram no rate limit e,
+    portanto, já tiveram ``count`` contabilizado). O ramo defensivo cria a linha
+    caso, por corrida, ainda não exista — mantendo ``error_count <= count``.
+    """
+    window_start = _day_window_start()
+    record = (
+        await session.execute(
+            select(UsageRecord).where(
+                UsageRecord.api_key_id == api_key_id,
+                UsageRecord.bucket == bucket,
+                UsageRecord.window_start == window_start,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if record is None:  # defensivo — não deveria ocorrer no fluxo normal
+        record = UsageRecord(
+            api_key_id=api_key_id,
+            bucket=bucket,
+            window_start=window_start,
+            count=1,
+            error_count=1,
+        )
+        session.add(record)
+        try:
+            await session.commit()
+            return
+        except IntegrityError:
+            await session.rollback()
+            record = (
+                await session.execute(
+                    select(UsageRecord).where(
+                        UsageRecord.api_key_id == api_key_id,
+                        UsageRecord.bucket == bucket,
+                        UsageRecord.window_start == window_start,
+                    )
+                )
+            ).scalar_one()
+
+    record.error_count += 1
+    await session.commit()
+
+
 async def key_usage(session: AsyncSession, api_key_id: str) -> KeyUsageResponse:
     """Métricas de consumo de uma key: minuto (limiters) + dia (DB) + limites."""
     from app.core.deps import ai_limiter, deterministic_limiter
@@ -185,4 +237,131 @@ async def account_usage(session: AsyncSession, account_id: str) -> AccountUsageR
         total_keys=total_keys,
         deterministic_used_today=await _sum(UsageBucket.deterministic),
         ai_used_today=await _sum(UsageBucket.ai),
+    )
+
+
+def _as_date(value: datetime | date) -> date:
+    """Normaliza ``window_start`` (naive no SQLite, aware no Postgres) para ``date``."""
+    return value.date() if isinstance(value, datetime) else value
+
+
+async def account_analytics(
+    session: AsyncSession,
+    account_id: str,
+    days: int = ANALYTICS_WINDOW_DAYS,
+) -> AccountAnalyticsResponse:
+    """Série diária + KPIs de BI para o painel (todas as keys da conta).
+
+    Uma única varredura de ``usage_records`` cobre a janela atual **e** a anterior
+    (para o delta percentual). ``total`` = chamadas autorizadas do dia; ``successful``
+    = ``total - error_count``. Sem tráfego, ``success_rate`` é ``None`` (o painel
+    mostra "—" em vez de forçar 0%/100%).
+    """
+    days = max(1, days)
+    now = _now()
+    today = _day_window_start(now)
+    window_start = today - timedelta(days=days - 1)
+    prev_window_start = window_start - timedelta(days=days)
+
+    rows = (
+        await session.execute(
+            select(
+                UsageRecord.window_start,
+                UsageRecord.bucket,
+                func.sum(UsageRecord.count),
+                func.sum(UsageRecord.error_count),
+            )
+            .join(ApiKey, ApiKey.id == UsageRecord.api_key_id)
+            .where(
+                ApiKey.account_id == account_id,
+                UsageRecord.window_start >= prev_window_start,
+            )
+            .group_by(UsageRecord.window_start, UsageRecord.bucket)
+        )
+    ).all()
+
+    # Agrega por dia (total/erros/IA/determinístico) para a janela atual e a anterior.
+    per_day: dict[date, dict[str, int]] = {}
+    prev_total = 0
+    cur_start_date = window_start.date()
+    for ws, bucket, total, errors in rows:
+        d = _as_date(ws)
+        total = int(total or 0)
+        errors = int(errors or 0)
+        if d < cur_start_date:
+            prev_total += total
+            continue
+        day = per_day.setdefault(d, {"total": 0, "errors": 0, "ai": 0, "det": 0})
+        day["total"] += total
+        day["errors"] += errors
+        if bucket == UsageBucket.ai:
+            day["ai"] += total
+        else:
+            day["det"] += total
+
+    series: list[UsageDailyPoint] = []
+    total_requests = 0
+    failed_requests = 0
+    ai_requests = 0
+    deterministic_requests = 0
+    for i in range(days):
+        d = (window_start + timedelta(days=i)).date()
+        day = per_day.get(d, {"total": 0, "errors": 0, "ai": 0, "det": 0})
+        total = day["total"]
+        failed = min(day["errors"], total)
+        series.append(
+            UsageDailyPoint(date=d, total=total, successful=total - failed, failed=failed)
+        )
+        total_requests += total
+        failed_requests += failed
+        ai_requests += day["ai"]
+        deterministic_requests += day["det"]
+
+    successful_requests = total_requests - failed_requests
+    success_rate = (successful_requests / total_requests) if total_requests else None
+    delta_pct = ((total_requests - prev_total) / prev_total * 100.0) if prev_total else None
+
+    active_keys = int(
+        (
+            await session.execute(
+                select(func.count())
+                .select_from(ApiKey)
+                .where(
+                    ApiKey.account_id == account_id,
+                    ApiKey.status == ApiKeyStatus.active,
+                )
+            )
+        ).scalar_one()
+        or 0
+    )
+    week_ago = now - timedelta(days=7)
+    new_keys_last_7d = int(
+        (
+            await session.execute(
+                select(func.count())
+                .select_from(ApiKey)
+                .where(
+                    ApiKey.account_id == account_id,
+                    ApiKey.status == ApiKeyStatus.active,
+                    ApiKey.created_at >= week_ago,
+                )
+            )
+        ).scalar_one()
+        or 0
+    )
+
+    return AccountAnalyticsResponse(
+        account_id=account_id,
+        window_days=days,
+        series=series,
+        total_requests=total_requests,
+        successful_requests=successful_requests,
+        failed_requests=failed_requests,
+        success_rate=success_rate,
+        total_requests_prev=prev_total,
+        total_requests_delta_pct=delta_pct,
+        ai_requests=ai_requests,
+        deterministic_requests=deterministic_requests,
+        active_keys=active_keys,
+        new_keys_last_7d=new_keys_last_7d,
     )

--- a/app/web/charts.py
+++ b/app/web/charts.py
@@ -1,0 +1,156 @@
+"""
+Gráfico de área SSR determinístico (Princípio VII).
+
+Converte a série diária de uso (``UsageDailyPoint``) em geometria SVG pronta para
+o template — sem dependências de runtime, sem JS de renderização e sem CDN. O
+mesmo dado alimenta a tabela acessível (fallback) no painel. Puro e testável:
+recebe a série, devolve coordenadas/labels; não conhece HTTP nem o ORM.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+# Sistema de coordenadas do viewBox (o SVG escala via CSS; unidades são internas).
+_WIDTH = 840
+_HEIGHT = 260
+_PAD_L = 44
+_PAD_R = 12
+_PAD_T = 12
+_PAD_B = 26
+
+
+@dataclass
+class ChartPoint:
+    x: float
+    y_total: float
+    y_success: float
+    label: str  # dd/mm
+    total: int
+    successful: int
+
+
+@dataclass
+class AxisTick:
+    pos: float
+    label: str
+
+
+@dataclass
+class UsageChart:
+    width: int = _WIDTH
+    height: int = _HEIGHT
+    baseline: float = _HEIGHT - _PAD_B
+    max_value: int = 0
+    has_data: bool = False
+    total_line: str = ""
+    total_area: str = ""
+    success_line: str = ""
+    success_area: str = ""
+    points: list[ChartPoint] = field(default_factory=list)
+    y_ticks: list[AxisTick] = field(default_factory=list)
+    x_ticks: list[AxisTick] = field(default_factory=list)
+
+
+def _nice_num(value: float, round_up: bool) -> float:
+    """Arredonda para um número "bonito" (1/2/5 × 10ⁿ) — eixos legíveis."""
+    if value <= 0:
+        return 1.0
+    exp = math.floor(math.log10(value))
+    frac = value / (10**exp)
+    if round_up:
+        nice = 1 if frac <= 1 else 2 if frac <= 2 else 5 if frac <= 5 else 10
+    else:
+        nice = 1 if frac < 1.5 else 2 if frac < 3 else 5 if frac < 7 else 10
+    return nice * (10**exp)
+
+
+def _fmt_int(n: int) -> str:
+    """Milhar com ponto (pt-BR): 2500 → '2.500'."""
+    return f"{n:,}".replace(",", ".")
+
+
+def _fmt_date(d) -> str:
+    return f"{d.day:02d}/{d.month:02d}"
+
+
+def build_usage_chart(series: list) -> UsageChart:
+    """Monta a geometria do gráfico de área (total vs. bem-sucedidas)."""
+    chart = UsageChart()
+    n = len(series)
+    if n == 0:
+        return chart
+
+    peak = max((p.total for p in series), default=0)
+    chart.has_data = peak > 0
+
+    # Escala do eixo Y "bonita" com ~4 divisões (mínimo 4 p/ um eixo utilizável).
+    ticks = 4
+    nice_range = _nice_num(max(peak, 1), round_up=True)
+    step = _nice_num(nice_range / ticks, round_up=True)
+    max_value = int(step * ticks)
+    if max_value < 4:
+        max_value = 4
+        step = max_value / ticks
+    chart.max_value = max_value
+
+    plot_w = _WIDTH - _PAD_L - _PAD_R
+    plot_h = _HEIGHT - _PAD_T - _PAD_B
+
+    def x_at(i: int) -> float:
+        if n == 1:
+            return _PAD_L + plot_w / 2
+        return _PAD_L + plot_w * i / (n - 1)
+
+    def y_at(v: int) -> float:
+        return _PAD_T + plot_h * (1 - v / max_value)
+
+    total_pts: list[str] = []
+    success_pts: list[str] = []
+    for i, p in enumerate(series):
+        x = round(x_at(i), 2)
+        yt = round(y_at(p.total), 2)
+        ys = round(y_at(p.successful), 2)
+        total_pts.append(f"{x},{yt}")
+        success_pts.append(f"{x},{ys}")
+        chart.points.append(
+            ChartPoint(
+                x=x,
+                y_total=yt,
+                y_success=ys,
+                label=_fmt_date(p.date),
+                total=p.total,
+                successful=p.successful,
+            )
+        )
+
+    baseline = chart.baseline
+    first_x = chart.points[0].x
+    last_x = chart.points[-1].x
+    chart.total_line = " ".join(total_pts)
+    chart.success_line = " ".join(success_pts)
+    chart.total_area = (
+        f"M{first_x},{baseline} L" + " L".join(total_pts) + f" L{last_x},{baseline} Z"
+    )
+    chart.success_area = (
+        f"M{first_x},{baseline} L" + " L".join(success_pts) + f" L{last_x},{baseline} Z"
+    )
+
+    # Ticks do eixo Y.
+    i = 0
+    while i <= ticks:
+        v = int(round(step * i))
+        chart.y_ticks.append(AxisTick(pos=round(y_at(v), 2), label=_fmt_int(v)))
+        i += 1
+
+    # Ticks do eixo X: ~7 labels distribuídos, sempre incluindo o último dia.
+    max_labels = 7
+    stride = max(1, math.ceil(n / max_labels))
+    seen: set[int] = set()
+    for idx in list(range(0, n, stride)) + [n - 1]:
+        if idx in seen:
+            continue
+        seen.add(idx)
+        chart.x_ticks.append(AxisTick(pos=round(x_at(idx), 2), label=chart.points[idx].label))
+    return chart

--- a/app/web/portal.py
+++ b/app/web/portal.py
@@ -23,6 +23,7 @@ from fastapi.responses import RedirectResponse
 from app.core.config import settings
 from app.core.deps import (
     get_http_client,
+    rate_limit_forgot_ip,
     rate_limit_login_ip,
     rate_limit_oauth_ip,
     rate_limit_signup_ip,
@@ -30,6 +31,7 @@ from app.core.deps import (
 from app.core.security import create_access_token, decode_access_token
 from app.db.base import async_session_factory
 from app.db.tables import DeveloperAccount
+from app.models.platform import _validate_password_policy
 from app.services import (
     account_service,
     apikey_service,
@@ -37,6 +39,7 @@ from app.services import (
     onboarding_service,
     usage_service,
 )
+from app.web.charts import build_usage_chart
 from app.web.router import templates
 
 router = APIRouter()
@@ -382,10 +385,19 @@ async def _render_dashboard(
     async with async_session_factory() as session:
         keys = await apikey_service.list_keys(session, account.id)
         usage = await usage_service.account_usage(session, account.id)
+        analytics = await usage_service.account_analytics(session, account.id)
+    chart = build_usage_chart(analytics.series)
     return templates.TemplateResponse(
         request,
         "portal/dashboard.html",
-        {"account": account, "keys": keys, "usage": usage, "new_key": new_key},
+        {
+            "account": account,
+            "keys": keys,
+            "usage": usage,
+            "analytics": analytics,
+            "chart": chart,
+            "new_key": new_key,
+        },
     )
 
 
@@ -428,6 +440,140 @@ async def dashboard_revoke_key(request: Request, key_id: str):
         except Exception:
             pass
     return RedirectResponse(url="/portal/dashboard", status_code=status.HTTP_303_SEE_OTHER)
+
+
+# --------------------------------------------------------------------------- #
+# Segurança da conta — trocar senha (requer sessão)
+# --------------------------------------------------------------------------- #
+@router.get("/account/password")
+async def change_password_page(request: Request, error: str | None = None, info: str | None = None):
+    account = await _account_from_request(request)
+    if account is None:
+        return RedirectResponse(url="/portal/login", status_code=status.HTTP_303_SEE_OTHER)
+    return templates.TemplateResponse(
+        request,
+        "portal/change_password.html",
+        {"account": account, "error": error, "info": info},
+    )
+
+
+@router.post("/account/password")
+async def change_password_submit(
+    request: Request,
+    current_password: str = Form(...),
+    new_password: str = Form(...),
+    confirm_password: str = Form(...),
+):
+    account = await _account_from_request(request)
+    if account is None:
+        return RedirectResponse(url="/portal/login", status_code=status.HTTP_303_SEE_OTHER)
+
+    def _error(msg: str):
+        return templates.TemplateResponse(
+            request,
+            "portal/change_password.html",
+            {"account": account, "error": msg},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if new_password != confirm_password:
+        return _error("A confirmação não corresponde à nova senha.")
+    try:
+        _validate_password_policy(new_password)
+    except ValueError as exc:
+        return _error(str(exc))
+
+    async with async_session_factory() as session:
+        # Recarrega a conta nesta sessão para persistir a alteração.
+        db_account = await session.get(DeveloperAccount, account.id)
+        try:
+            await account_service.change_password(
+                session, db_account, current_password, new_password
+            )
+        except Exception:
+            return _error("Senha atual incorreta.")
+
+    return templates.TemplateResponse(
+        request,
+        "portal/change_password.html",
+        {"account": account, "info": "Senha alterada com sucesso."},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Recuperação de senha — esqueci a senha / redefinir (públicos)
+# --------------------------------------------------------------------------- #
+@router.get("/forgot-password")
+async def forgot_password_page(request: Request, info: str | None = None):
+    return templates.TemplateResponse(request, "portal/forgot_password.html", {"info": info})
+
+
+@router.post("/forgot-password")
+async def forgot_password_submit(
+    request: Request,
+    email: str = Form(...),
+    _rate_limit: None = Depends(rate_limit_forgot_ip),
+):
+    async with async_session_factory() as session:
+        try:
+            await account_service.request_password_reset(session, email)
+        except Exception:
+            logger.exception("Falha ao processar pedido de redefinição de senha")
+    # Resposta idêntica exista ou não a conta (anti-enumeração — Princípio V).
+    return templates.TemplateResponse(
+        request,
+        "portal/forgot_password.html",
+        {"info": "Se houver uma conta para este e-mail, enviamos um link de redefinição."},
+    )
+
+
+@router.get("/reset-password")
+async def reset_password_page(request: Request, token: str | None = None, error: str | None = None):
+    if not token:
+        return templates.TemplateResponse(
+            request,
+            "portal/login.html",
+            {"error": "Link de redefinição inválido ou ausente.", **_oauth_context()},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    return templates.TemplateResponse(
+        request, "portal/reset_password.html", {"token": token, "error": error}
+    )
+
+
+@router.post("/reset-password")
+async def reset_password_submit(
+    request: Request,
+    token: str = Form(...),
+    new_password: str = Form(...),
+    confirm_password: str = Form(...),
+):
+    def _error(msg: str):
+        return templates.TemplateResponse(
+            request,
+            "portal/reset_password.html",
+            {"token": token, "error": msg},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if new_password != confirm_password:
+        return _error("A confirmação não corresponde à nova senha.")
+    try:
+        _validate_password_policy(new_password)
+    except ValueError as exc:
+        return _error(str(exc))
+
+    async with async_session_factory() as session:
+        try:
+            await account_service.reset_password(session, token, new_password)
+        except Exception:
+            return _error("Link de redefinição inválido, expirado ou já utilizado.")
+
+    return templates.TemplateResponse(
+        request,
+        "portal/login.html",
+        {"info": "Senha redefinida. Faça login com a nova senha.", **_oauth_context()},
+    )
 
 
 @router.get("/logout")

--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -9,10 +9,13 @@
 /* ------------------------------ Tokens ---------------------------------- */
 :root {
   --bg: #ffffff;
-  --bg-soft: #f7f8fa;
-  --fg: #16181d;
-  --fg-muted: #5b6270;
-  --border: #e4e7ec;
+  --bg-soft: #f6f7f9;
+  --bg-sunken: #f0f2f5;
+  --fg: #0e1117;
+  --fg-muted: #5a6270;
+  --fg-subtle: #8a92a0;
+  --border: #e7e9ee;
+  --border-strong: #d6d9e0;
   --brand: #1b4dff;
   --brand-strong: #1640d9;
   --brand-fg: #ffffff;
@@ -20,30 +23,53 @@
   --accent: #0d9488;
   --danger: #b42318;
   --danger-soft: #fef3f2;
-  --code-bg: #0f172a;
+  --ok: #0a7d5a;
+  --ok-soft: #e7f7f0;
+  /* Séries do gráfico de uso (BI): total (marca) vs. bem-sucedidas (verde). */
+  --chart-total: var(--brand);
+  --chart-success: #0a9d6e;
+  --chart-total-fill: rgba(27, 77, 255, 0.12);
+  --chart-success-fill: rgba(10, 157, 110, 0.12);
+  --chart-grid: var(--border);
+  --code-bg: #0b1020;
   --code-fg: #e2e8f0;
   --code-key: #7dd3fc;
   --code-val: #86efac;
-  --shadow: 0 1px 2px rgb(16 24 40 / 0.06), 0 8px 24px rgb(16 24 40 / 0.08);
-  --radius: 10px;
+  --shadow-sm: 0 1px 2px rgb(15 23 42 / 0.05);
+  --shadow: 0 1px 2px rgb(15 23 42 / 0.05), 0 12px 28px -10px rgb(15 23 42 / 0.12);
+  --shadow-lg: 0 24px 60px -18px rgb(15 23 42 / 0.24);
+  --radius-sm: 8px;
+  --radius: 12px;
+  --radius-lg: 18px;
   --maxw: 72rem;
   --font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0d0f14;
-    --bg-soft: #151922;
-    --fg: #e8eaed;
+    --bg: #0b0d12;
+    --bg-soft: #12151d;
+    --bg-sunken: #0e1117;
+    --fg: #eceef2;
     --fg-muted: #9aa2b1;
-    --border: #262b36;
-    --brand: #5b7bff;
-    --brand-strong: #7590ff;
-    --brand-soft: #1a2036;
+    --fg-subtle: #6b7280;
+    --border: #23272f;
+    --border-strong: #333844;
+    --brand: #6b8aff;
+    --brand-strong: #86a0ff;
+    --brand-soft: #161d33;
     --danger: #f97066;
     --danger-soft: #2a1715;
-    --code-bg: #10141d;
-    --shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px rgb(0 0 0 / 0.45);
+    --ok: #34d399;
+    --ok-soft: #0f2a22;
+    --chart-total: #6b8aff;
+    --chart-success: #34d399;
+    --chart-total-fill: rgba(107, 138, 255, 0.16);
+    --chart-success-fill: rgba(52, 211, 153, 0.14);
+    --code-bg: #0a0e18;
+    --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.4);
+    --shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 16px 36px -14px rgb(0 0 0 / 0.6);
+    --shadow-lg: 0 30px 70px -20px rgb(0 0 0 / 0.7);
   }
 }
 
@@ -60,17 +86,22 @@ body {
   background: var(--bg);
   line-height: 1.6;
   font-size: 17px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 a { color: var(--brand); text-decoration: none; }
 a:hover { text-decoration: underline; }
-h1, h2, h3 { line-height: 1.2; letter-spacing: -0.02em; }
-h1 { font-size: clamp(2rem, 5vw, 3.25rem); margin: 0 0 1rem; }
-h2 { font-size: clamp(1.5rem, 3vw, 2rem); margin: 2.5rem 0 1rem; }
+h1, h2, h3 { line-height: 1.15; letter-spacing: -0.021em; text-wrap: balance; }
+h1 { font-size: clamp(2.25rem, 5.2vw, 3.6rem); margin: 0 0 1.1rem; letter-spacing: -0.03em; }
+h2 { font-size: clamp(1.6rem, 3.2vw, 2.15rem); margin: 2.5rem 0 1rem; }
+p { text-wrap: pretty; }
 .muted { color: var(--fg-muted); }
-.container { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem; }
-.section { padding: 3rem 0; }
+.container { max-width: var(--maxw); margin: 0 auto; padding: 0 1.5rem; }
+.section { padding: 4.5rem 0; }
 .section-narrow { max-width: 52rem; }
-.lead { font-size: 1.25rem; color: var(--fg-muted); max-width: 42rem; }
+/* Header sticky: âncoras (#apoie, #casos-de-uso…) não escondem sob a barra. */
+:where(section, [id])[id] { scroll-margin-top: 5rem; }
+.lead { font-size: 1.2rem; line-height: 1.55; color: var(--fg-muted); max-width: 40rem; }
 
 /* Foco visível e movimento reduzido (a11y) */
 a:focus-visible, button:focus-visible, .btn:focus-visible {
@@ -82,10 +113,17 @@ a:focus-visible, button:focus-visible, .btn:focus-visible {
 }
 
 /* ------------------------------ Header ---------------------------------- */
-.site-header { border-bottom: 1px solid var(--border); background: var(--bg); }
+.site-header {
+  position: sticky; top: 0; z-index: 50;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+}
+@supports (backdrop-filter: blur(8px)) {
+  .site-header { backdrop-filter: saturate(140%) blur(10px); }
+}
 .nav {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 1rem 0; gap: 1rem;
+  padding: 0.9rem 0; gap: 1rem;
 }
 .brand {
   display: inline-flex; align-items: center; gap: 0.55rem;
@@ -124,32 +162,40 @@ a:focus-visible, button:focus-visible, .btn:focus-visible {
 
 /* ------------------------------ Botões ----------------------------------- */
 .btn {
-  display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem;
-  padding: 0.7rem 1.2rem; border-radius: var(--radius); min-height: 44px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem;
+  padding: 0.68rem 1.25rem; border-radius: var(--radius); min-height: 44px;
   background: var(--brand); color: var(--brand-fg); font-weight: 600;
-  font-size: 1rem; font-family: inherit; line-height: 1.2;
+  font-size: 1rem; font-family: inherit; line-height: 1.2; letter-spacing: -0.01em;
   border: 1px solid transparent; cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease,
+    transform 0.18s ease, box-shadow 0.18s ease;
 }
 .btn:hover { text-decoration: none; background: var(--brand-strong); }
-/* CTA primário ganha leve elevação para se destacar (hierarquia de ação). */
+/* CTA primário: elevação discreta e micro-lift (hierarquia de ação sem estridência). */
 .btn:not(.btn-secondary):not(.btn-oauth):not(.btn-danger) {
-  box-shadow: 0 1px 2px rgb(27 77 255 / 0.18), 0 6px 16px rgb(27 77 255 / 0.16);
+  box-shadow: 0 1px 2px rgb(27 77 255 / 0.16), 0 8px 20px -8px rgb(27 77 255 / 0.42);
 }
-.btn:not(.btn-secondary):not(.btn-oauth):not(.btn-danger):hover { box-shadow: 0 2px 4px rgb(27 77 255 / 0.22), 0 10px 24px rgb(27 77 255 / 0.20); }
-.btn-secondary { background: transparent; color: var(--brand); border-color: var(--border); }
-.btn-secondary:hover { background: var(--brand-soft); border-color: var(--brand); }
+.btn:not(.btn-secondary):not(.btn-oauth):not(.btn-danger):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgb(27 77 255 / 0.18), 0 12px 26px -8px rgb(27 77 255 / 0.5);
+}
+.btn:active { transform: translateY(0); }
+.btn-secondary { background: var(--bg); color: var(--fg); border-color: var(--border-strong); box-shadow: var(--shadow-sm); }
+.btn-secondary:hover { background: var(--bg-soft); border-color: var(--fg-subtle); }
 .btn-danger { background: var(--danger); }
 .btn-danger:hover { background: var(--danger); opacity: 0.88; }
-.btn-lg { padding: 0.85rem 1.5rem; font-size: 1.05rem; }
+.btn-lg { padding: 0.85rem 1.6rem; font-size: 1.05rem; min-height: 50px; }
 .btn-sm { padding: 0.45rem 0.9rem; font-size: 0.9rem; min-height: 36px; }
 .btn-block { width: 100%; }
 .cta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+@media (prefers-reduced-motion: reduce) { .btn:hover, .btn:active { transform: none; } }
 
 /* ------------------------------ Cards e grids ---------------------------- */
-.grid { display: grid; gap: 1.25rem; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); }
+.grid { display: grid; gap: 1.1rem; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); }
 .card {
   border: 1px solid var(--border); border-radius: var(--radius);
-  padding: 1.25rem; background: var(--bg-soft);
+  padding: 1.4rem; background: var(--bg-soft);
+  transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 /* ------------------------------ Código e tabelas ------------------------- */
@@ -167,36 +213,56 @@ th {
 }
 
 /* ------------------------------ Formulários ------------------------------ */
-form label { display: block; font-weight: 600; margin: 1rem 0 0.35rem; }
+form label { display: block; font-weight: 600; font-size: 0.92rem; margin: 1.1rem 0 0.4rem; }
 input, select, textarea {
-  width: 100%; padding: 0.6rem 0.75rem; border: 1px solid var(--border);
+  width: 100%; padding: 0.7rem 0.85rem; border: 1px solid var(--border-strong);
   border-radius: var(--radius); background: var(--bg); color: var(--fg);
-  font-size: 1rem; font-family: inherit; min-height: 44px;
+  font-size: 1rem; font-family: inherit; min-height: 46px;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
 }
+input::placeholder, textarea::placeholder { color: var(--fg-subtle); }
 input:focus-visible, select:focus-visible, textarea:focus-visible {
   outline: none; border-color: var(--brand);
   box-shadow: 0 0 0 3px var(--brand-soft);
 }
 .form-help { color: var(--fg-muted); font-size: 0.85rem; margin: 0.35rem 0 0; }
+.form-help-right { text-align: right; margin-top: 0.85rem; }
+.form-help-right a { font-weight: 500; }
 .form-actions { margin-top: 1.5rem; }
 .form-footer { color: var(--fg-muted); margin-top: 1rem; }
 
-/* Página de autenticação (login/signup) */
-.auth-wrap { max-width: 28rem; }
-.auth-card { box-shadow: var(--shadow); background: var(--bg); padding: 1.5rem; }
+/* Página de autenticação (login/signup) — coluna central, respiro e foco. */
+.auth-wrap { max-width: 26rem; padding-top: 3.5rem; padding-bottom: 4.5rem; text-align: center; }
+.auth-mark {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 3rem; height: 3rem; margin-bottom: 1.25rem;
+}
+.auth-mark svg { width: 2.6rem; height: 2.6rem; }
+.auth-wrap h1 { font-size: clamp(1.6rem, 4vw, 2rem); }
+.auth-wrap > .lead { margin: 0.5rem auto 2rem; font-size: 1.05rem; max-width: 24rem; }
+.auth-card {
+  box-shadow: var(--shadow); background: var(--bg); padding: 1.75rem; text-align: left;
+  border-radius: var(--radius-lg); border-color: var(--border-strong);
+}
+.auth-wrap .notice { text-align: left; }
 /* Primeiro rótulo do formulário (quando não há OAuth acima) sem margem extra. */
 .auth-form label:first-child { margin-top: 0; }
+.auth-form .form-actions { margin-top: 1.75rem; }
+.form-footer { color: var(--fg-muted); margin-top: 1.25rem; text-align: center; }
+.form-footer a { font-weight: 600; }
 
 /* Login social (Google / GitHub) — prioridade, no topo do card */
 .oauth-buttons { display: flex; flex-direction: column; gap: 0.6rem; }
 .btn-oauth {
-  background: var(--bg); color: var(--fg); border-color: var(--border); font-weight: 500;
+  background: var(--bg); color: var(--fg); border-color: var(--border-strong);
+  font-weight: 500; box-shadow: var(--shadow-sm);
 }
-.btn-oauth:hover { background: var(--brand-soft); border-color: var(--brand); }
+.btn-oauth:hover { background: var(--bg-soft); border-color: var(--fg-subtle); }
 .btn-oauth svg { flex: 0 0 auto; }
 .oauth-divider {
-  display: flex; align-items: center; gap: 0.75rem;
-  color: var(--fg-muted); font-size: 0.85rem; margin: 1.25rem 0 0.5rem;
+  display: flex; align-items: center; gap: 0.85rem;
+  color: var(--fg-subtle); font-size: 0.8rem; margin: 1.4rem 0 0.35rem;
+  text-transform: lowercase; letter-spacing: 0.01em;
 }
 .oauth-divider::before, .oauth-divider::after {
   content: ""; flex: 1; height: 1px; background: var(--border);
@@ -232,22 +298,39 @@ input[type="password"]::-ms-clear { display: none; }
    Landing comercial (v2)
    ========================================================================= */
 .eyebrow {
-  display: inline-block; font-size: 0.85rem; font-weight: 600; letter-spacing: 0.02em;
-  color: var(--brand); background: var(--brand-soft); border: 1px solid var(--border);
-  padding: 0.25rem 0.75rem; border-radius: 999px; margin: 0 0 1rem;
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  font-size: 0.8rem; font-weight: 600; letter-spacing: 0.01em;
+  color: var(--fg-muted); background: var(--bg-soft); border: 1px solid var(--border);
+  padding: 0.3rem 0.85rem 0.3rem 0.7rem; border-radius: 999px; margin: 0 0 1.4rem;
 }
-.hero { padding: 4rem 0 3rem; }
+.eyebrow::before {
+  content: ""; width: 0.45rem; height: 0.45rem; border-radius: 50%;
+  background: var(--accent); flex: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.hero { padding: 5rem 0 4rem; }
 .hero-grid {
-  display: grid; gap: 2.5rem; align-items: center;
-  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  display: grid; gap: 3rem; align-items: center;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
 }
-@media (max-width: 820px) { .hero-grid { grid-template-columns: 1fr; } }
-.hero-note { font-size: 0.9rem; margin-top: 0.5rem; }
+@media (max-width: 820px) { .hero-grid { grid-template-columns: 1fr; gap: 2.25rem; } }
+.hero .lead { font-size: 1.25rem; max-width: 34rem; }
+.hero .cta-row { margin-top: 1.75rem; }
+.hero-note {
+  font-size: 0.88rem; margin-top: 0.85rem; color: var(--fg-subtle);
+  display: inline-flex; align-items: center; gap: 0.45rem;
+}
+.hero-note::before {
+  content: ""; width: 1.05rem; height: 1.05rem; flex: none;
+  background: currentColor;
+  -webkit-mask: no-repeat center / contain url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+  mask: no-repeat center / contain url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+}
 
 /* Janela de código */
 .code-window {
-  background: var(--code-bg); color: var(--code-fg); border-radius: 14px;
-  border: 1px solid var(--border); box-shadow: var(--shadow); overflow: hidden;
+  background: var(--code-bg); color: var(--code-fg); border-radius: var(--radius-lg);
+  border: 1px solid rgb(255 255 255 / 0.08); box-shadow: var(--shadow-lg); overflow: hidden;
   font-size: 0.88rem;
 }
 .code-window pre { background: transparent; border: 0; margin: 0; padding: 1.1rem 1.25rem; }
@@ -265,15 +348,20 @@ input[type="password"]::-ms-clear { display: none; }
 .stat-strip { background: var(--bg-soft); border-block: 1px solid var(--border); }
 .stat-grid {
   display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-  gap: 1rem; padding: 1.75rem 1.25rem; text-align: center;
+  gap: 1rem 2rem; padding: 2.25rem 1.5rem; text-align: center;
 }
-.stat strong { display: block; font-size: 1.9rem; letter-spacing: -0.02em; color: var(--fg); }
-.stat span { color: var(--fg-muted); font-size: 0.95rem; }
+.stat strong {
+  display: block; font-size: 2.35rem; font-weight: 700; letter-spacing: -0.04em;
+  color: var(--fg); font-variant-numeric: tabular-nums; line-height: 1.05;
+}
+.stat span { display: block; margin-top: 0.35rem; color: var(--fg-muted); font-size: 0.92rem; }
 
 /* Casos de uso */
-.uc-grid { grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); margin-top: 1.5rem; }
-.uc-card { display: flex; flex-direction: column; gap: 0.35rem; box-shadow: none; }
-.uc-card h3 { margin: 0.25rem 0 0; font-size: 1.12rem; }
+.uc-grid { grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); margin-top: 2rem; }
+.uc-card { display: flex; flex-direction: column; gap: 0.4rem; box-shadow: none; }
+.uc-card:hover { border-color: var(--border-strong); transform: translateY(-2px); box-shadow: var(--shadow); }
+.uc-card h3 { margin: 0.4rem 0 0; font-size: 1.1rem; letter-spacing: -0.01em; }
+@media (prefers-reduced-motion: reduce) { .uc-card:hover { transform: none; } }
 .uc-card p:last-child { margin-top: auto; display: flex; flex-wrap: wrap; gap: 0.4rem; }
 .uc-icon {
   display: inline-flex; align-items: center; justify-content: center;
@@ -337,10 +425,21 @@ input[type="password"]::-ms-clear { display: none; }
 }
 .pix-copy .btn { align-self: flex-start; }
 
-/* CTA final */
+/* CTA final — painel destacado, centralizado */
 .cta-final { text-align: center; }
+.cta-final-inner {
+  position: relative; overflow: hidden;
+  padding: 3.5rem 1.75rem; border-radius: var(--radius-lg);
+  border: 1px solid var(--border); background: var(--bg-soft);
+}
+.cta-final-inner::before {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(60rem 22rem at 50% -30%, var(--brand-soft), transparent 70%);
+}
+.cta-final-inner > * { position: relative; }
+.cta-final h2 { margin-top: 0; }
 .cta-final .lead { margin-inline: auto; }
-.cta-final .cta-row { justify-content: center; }
+.cta-final .cta-row { justify-content: center; margin-top: 1.75rem; }
 
 /* ------------------------------ Rodapé ----------------------------------- */
 .site-footer { border-top: 1px solid var(--border); background: var(--bg); color: var(--fg-muted); }
@@ -608,4 +707,128 @@ input[type="password"]::-ms-clear { display: none; }
   .lead { font-size: 1.1rem; }
   .cta-row .btn { width: 100%; }
   .page-header { align-items: flex-start; }
+}
+
+/* =========================================================================
+   Painel & Analytics (BI) — portal/dashboard.html
+   Shell com sidebar, gráfico de área SSR, KPIs e tabela de keys. Tudo por
+   tokens (tema claro/escuro automático). Ver app/web/charts.py.
+   ========================================================================= */
+.dash { padding-top: 2rem; }
+.dash-shell {
+  display: grid; grid-template-columns: 236px minmax(0, 1fr);
+  gap: 1.75rem; align-items: start;
+}
+.dash-main { min-width: 0; }
+
+/* Sidebar */
+.dash-side {
+  position: sticky; top: 1.5rem; display: flex; flex-direction: column;
+  gap: 1rem; padding: 1rem; border: 1px solid var(--border);
+  border-radius: var(--radius); background: var(--bg-soft);
+}
+.dash-nav { display: flex; flex-direction: column; gap: 0.15rem; }
+.dash-nav-item {
+  display: flex; align-items: center; gap: 0.6rem; min-height: 44px;
+  padding: 0.55rem 0.7rem; border-radius: var(--radius-sm);
+  color: var(--fg-muted); font-weight: 500;
+}
+.dash-nav-item:hover { background: var(--bg); color: var(--fg); text-decoration: none; }
+.dash-nav-item.is-active { background: var(--brand-soft); color: var(--brand); }
+.dash-nav-item svg { flex: none; }
+.dash-account { border-top: 1px solid var(--border); padding-top: 1rem; display: flex; flex-direction: column; gap: 0.6rem; }
+.dash-account-id { display: flex; gap: 0.6rem; align-items: center; min-width: 0; }
+.dash-avatar {
+  width: 2.1rem; height: 2.1rem; border-radius: 50%; flex: none;
+  background: var(--brand); color: var(--brand-fg);
+  display: inline-flex; align-items: center; justify-content: center; font-weight: 700;
+}
+.dash-account-meta { display: flex; flex-direction: column; gap: 0.25rem; min-width: 0; }
+.dash-account-email { font-size: 0.82rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Cabeçalho e seções */
+.dash-head h1 { margin: 0 0 0.25rem; font-size: clamp(1.6rem, 3vw, 2.15rem); }
+.dash-sub { margin: 0; }
+.dash-section-title { font-size: 1.15rem; margin: 2rem 0 1rem; }
+
+/* Cartão do gráfico */
+.chart-card { padding: 1.25rem 1.25rem 1rem; background: var(--bg); box-shadow: var(--shadow-sm); }
+.chart-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.85rem; }
+.chart-title { font-weight: 700; margin: 0; font-size: 1.02rem; }
+.chart-caption { margin: 0.15rem 0 0; font-size: 0.85rem; }
+.chart-legend { list-style: none; display: flex; gap: 1rem; margin: 0; padding: 0; font-size: 0.8rem; color: var(--fg-muted); }
+.chart-legend li { display: inline-flex; align-items: center; gap: 0.4rem; }
+.dot { width: 0.6rem; height: 0.6rem; border-radius: 50%; display: inline-block; flex: none; }
+.dot-total { background: var(--chart-total); }
+.dot-success { background: var(--chart-success); }
+
+.chart-wrap { position: relative; }
+.usage-chart { width: 100%; height: auto; display: block; overflow: visible; }
+.chart-grid { stroke: var(--chart-grid); stroke-width: 1; }
+.chart-axis { fill: var(--fg-muted); font-size: 11px; font-family: var(--font); }
+.chart-area { stroke: none; }
+.chart-area-total { fill: var(--chart-total-fill); }
+.chart-area-success { fill: var(--chart-success-fill); }
+.chart-line { fill: none; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+.chart-line-total { stroke: var(--chart-total); }
+.chart-line-success { stroke: var(--chart-success); }
+.chart-dot { fill: var(--bg); stroke: var(--chart-total); stroke-width: 2; opacity: 0; cursor: pointer; }
+.chart-dot { r: 3; }
+.chart-dot:hover, .chart-dot.is-active, .chart-dot:focus-visible { opacity: 1; r: 4; outline: none; }
+
+.chart-tip {
+  position: absolute; transform: translate(-50%, -132%); z-index: 5;
+  background: var(--fg); color: var(--bg); padding: 0.5rem 0.65rem;
+  border-radius: var(--radius-sm); font-size: 0.78rem; pointer-events: none;
+  white-space: nowrap; box-shadow: var(--shadow); display: flex;
+  flex-direction: column; gap: 0.15rem;
+}
+.chart-tip strong { font-size: 0.8rem; }
+.chart-tip span { display: inline-flex; align-items: center; gap: 0.35rem; }
+.chart-tip .dot { width: 0.5rem; height: 0.5rem; }
+.chart-data { margin-top: 0.85rem; }
+.chart-data summary { cursor: pointer; color: var(--fg-muted); font-size: 0.85rem; min-height: 36px; display: inline-flex; align-items: center; }
+.chart-empty { padding: 2.5rem 1rem; text-align: center; }
+
+/* KPIs */
+.kpi-grid { grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr)); margin-top: 1.25rem; }
+.kpi { background: var(--bg); display: flex; flex-direction: column; gap: 0.35rem; box-shadow: var(--shadow-sm); }
+.kpi-label { color: var(--fg-muted); font-size: 0.85rem; margin: 0; font-weight: 500; }
+.kpi-value { font-size: clamp(1.7rem, 3.5vw, 2.1rem); font-weight: 700; letter-spacing: -0.02em; margin: 0; line-height: 1.1; font-variant-numeric: tabular-nums; }
+.kpi-delta { margin: 0; font-size: 0.8rem; }
+.kpi-delta.is-up { color: var(--ok); font-weight: 600; }
+.kpi-delta.is-down { color: var(--danger); font-weight: 600; }
+.kpi-meter { height: 0.4rem; border-radius: 999px; background: var(--bg-sunken); overflow: hidden; margin: 0.1rem 0; }
+.kpi-meter span { display: block; height: 100%; background: var(--ok); border-radius: inherit; }
+
+/* Pílulas de status (keys, conta) */
+.pill {
+  display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem;
+  font-weight: 600; padding: 0.15rem 0.55rem; border-radius: 999px;
+  letter-spacing: 0.02em; text-transform: uppercase;
+}
+.pill-ok { color: var(--ok); background: var(--ok-soft); }
+.pill-muted { color: var(--fg-muted); background: var(--bg-sunken); border: 1px solid var(--border); }
+
+/* Tabela de keys refinada */
+.keys-table td, .keys-table th { vertical-align: middle; }
+.keys-table code { font-size: 0.85rem; }
+
+/* Diversos */
+.form-help-right { text-align: right; margin-top: 0.4rem; }
+.form-help-right a { font-weight: 500; }
+.crumb { margin-bottom: 0.6rem; font-size: 0.9rem; }
+.crumb a { color: var(--fg-muted); }
+
+/* Responsivo: sidebar vira barra rolável no topo */
+@media (max-width: 900px) {
+  .dash-shell { grid-template-columns: 1fr; gap: 1.25rem; }
+  .dash-side { position: static; }
+  .dash-nav { flex-direction: row; overflow-x: auto; gap: 0.35rem; padding-bottom: 0.25rem; }
+  .dash-nav-item { flex: none; }
+  .dash-account { flex-direction: row; align-items: center; justify-content: space-between; }
+  .dash-account .btn-block { width: auto; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .chart-dot { transition: opacity 0.15s ease; }
 }

--- a/app/web/templates/portal/change_password.html
+++ b/app/web/templates/portal/change_password.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}Trocar senha — BNCC API{% endblock %}
+{% block description %}Altere a senha da sua conta da BNCC API.{% endblock %}
+{% block robots %}<meta name="robots" content="noindex">{% endblock %}
+
+{% block content %}
+<div class="container section section-narrow">
+  <nav class="crumb" aria-label="Trilha">
+    <a href="/portal/dashboard">← Voltar ao painel</a>
+  </nav>
+  <h1>Trocar senha</h1>
+  <p class="lead">Confirme a senha atual e escolha uma nova para <strong>{{ account.email }}</strong>.</p>
+
+  {% if info %}<div class="notice" role="status">{{ info }}</div>{% endif %}
+  {% if error %}<div class="notice notice-danger" role="alert">{{ error }}</div>{% endif %}
+
+  <div class="card auth-card">
+    <form method="post" action="/portal/account/password" class="auth-form">
+      <label for="current_password">Senha atual</label>
+      <div class="input-affix">
+        <input id="current_password" name="current_password" type="password" autocomplete="current-password" required>
+        <button type="button" class="input-affix-btn" data-toggle-password="current_password" aria-label="Mostrar senha" aria-pressed="false"><!-- pragma: allowlist secret -->
+          <svg class="icon-eye" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+          <svg class="icon-eye-off" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c6.5 0 10 8 10 8a18.5 18.5 0 0 1-2.16 3.19M6.61 6.61A18.5 18.5 0 0 0 2 12s3.5 7 10 7a9.12 9.12 0 0 0 5.39-1.61"/><path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/><path d="m2 2 20 20"/></svg>
+        </button>
+      </div>
+
+      <label for="new_password">Nova senha</label>
+      <input id="new_password" name="new_password" type="password" autocomplete="new-password"
+             minlength="10" required aria-describedby="pw-help">
+      <p class="form-help" id="pw-help">Mín. 10 caracteres, com letras e números.</p>
+
+      <label for="confirm_password">Confirmar nova senha</label>
+      <input id="confirm_password" name="confirm_password" type="password" autocomplete="new-password"
+             minlength="10" required>
+
+      <div class="form-actions">
+        <button class="btn btn-block" type="submit">Salvar nova senha</button>
+      </div>
+    </form>
+  </div>
+
+  <p class="form-footer">
+    Esqueceu a senha atual? <a href="/portal/forgot-password">Redefina por e-mail</a>
+  </p>
+</div>
+{% endblock %}

--- a/app/web/templates/portal/dashboard.html
+++ b/app/web/templates/portal/dashboard.html
@@ -1,112 +1,296 @@
 {% extends "base.html" %}
 
-{% block title %}Painel — BNCC API{% endblock %}
-{% block description %}Painel do portal da BNCC API: gerencie suas API keys e acompanhe o consumo diário.{% endblock %}
+{% block title %}Painel & Analytics — BNCC API{% endblock %}
+{% block description %}Painel do portal da BNCC API: acompanhe o uso ao longo do mês, taxa de sucesso e gerencie suas API keys.{% endblock %}
 {% block robots %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block content %}
-<div class="container section">
-  <div class="page-header">
-    <div>
-      <h1>Painel</h1>
-      <p class="lead account-line">
-        <span>{{ account.email }}</span>
-        {% if account.email_verified %}
-          <span class="badge">verificado</span>
-        {% else %}
-          <span class="badge badge-muted">não verificado</span>
-        {% endif %}
-      </p>
-    </div>
-    <a href="/portal/logout" class="btn btn-secondary">Sair</a>
-  </div>
+{% set delta = analytics.total_requests_delta_pct %}
+<div class="container section dash">
+  <div class="dash-shell">
+    <!-- Sidebar de navegação do painel (reflui para o topo no mobile) -->
+    <aside class="dash-side" aria-label="Navegação do painel">
+      <nav class="dash-nav">
+        <a class="dash-nav-item is-active" href="#painel" aria-current="true">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
+          <span>Painel</span>
+        </a>
+        <a class="dash-nav-item" href="#keys">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m16 6 3 3"/></svg>
+          <span>API Keys</span>
+        </a>
+        <a class="dash-nav-item" href="#analytics">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 3v18h18"/><path d="m7 14 4-4 3 3 5-6"/></svg>
+          <span>Uso &amp; Analytics</span>
+        </a>
+        <a class="dash-nav-item" href="/guia">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z"/></svg>
+          <span>Documentação</span>
+        </a>
+        <a class="dash-nav-item" href="/portal/account/password">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          <span>Segurança</span>
+        </a>
+      </nav>
+      <div class="dash-account">
+        <div class="dash-account-id">
+          <span class="dash-avatar" aria-hidden="true">{{ account.email[0]|upper }}</span>
+          <div class="dash-account-meta">
+            <span class="dash-account-email" title="{{ account.email }}">{{ account.email }}</span>
+            {% if account.email_verified %}
+              <span class="pill pill-ok">verificado</span>
+            {% else %}
+              <span class="pill pill-muted">não verificado</span>
+            {% endif %}
+          </div>
+        </div>
+        <a href="/portal/logout" class="btn btn-secondary btn-sm btn-block">Sair</a>
+      </div>
+    </aside>
 
-  {% if not account.email_verified %}
-  <div class="notice notice-danger" role="alert">
-    Verifique seu e-mail para liberar a geração de API keys.
-  </div>
-  {% endif %}
+    <!-- Conteúdo principal -->
+    <div class="dash-main" id="painel">
+      <div class="dash-head">
+        <div>
+          <h1>Painel &amp; Analytics</h1>
+          <p class="muted dash-sub">Visão de uso dos últimos {{ analytics.window_days }} dias.</p>
+        </div>
+      </div>
 
-  <h2>Consumo de hoje</h2>
-  <div class="grid metric-grid">
-    <div class="card metric">
-      <p class="metric-label">Keys ativas/criadas</p>
-      <p class="metric-value">{{ usage.total_keys }}</p>
-    </div>
-    <div class="card metric">
-      <p class="metric-label">Requisições determinísticas (hoje)</p>
-      <p class="metric-value">{{ usage.deterministic_used_today }}</p>
-    </div>
-    <div class="card metric">
-      <p class="metric-label">Requisições de IA (hoje)</p>
-      <p class="metric-value">{{ usage.ai_used_today }}</p>
-    </div>
-  </div>
+      {% if not account.email_verified %}
+      <div class="notice notice-danger" role="alert">
+        Verifique seu e-mail para liberar a geração de API keys.
+      </div>
+      {% endif %}
 
-  <h2>API keys</h2>
-  {% if account.email_verified %}
-  <form method="post" action="/portal/keys" class="card key-form">
-    <label for="name">Nome da nova key</label>
-    <div class="key-form-row">
-      <input id="name" name="name" type="text" maxlength="120" required
-             placeholder="ex.: integração-escola" aria-describedby="key-name-help">
-      <button class="btn" type="submit">Gerar nova key</button>
-    </div>
-    <p class="form-help" id="key-name-help">Um nome descritivo ajuda a saber o que revogar depois.</p>
-  </form>
-  {% endif %}
+      <!-- ===================== Usage Insights ===================== -->
+      <section id="analytics" aria-labelledby="analytics-title">
+        <h2 id="analytics-title" class="dash-section-title">Uso ao longo do mês</h2>
 
-  {% if keys %}
-  <div class="table-wrap">
-  <table>
-    <thead>
-      <tr>
-        <th scope="col">Nome</th>
-        <th scope="col">Prefixo</th>
-        <th scope="col">Status</th>
-        <th scope="col">Criada</th>
-        <th scope="col">Último uso</th>
-        <th scope="col"><span class="sr-only">Ações</span></th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for k in keys %}
-      <tr>
-        <td data-label="Nome">{{ k.name }}</td>
-        <td data-label="Prefixo"><code>{{ k.prefix }}</code></td>
-        <td data-label="Status">
-          {% if k.status.value == 'active' %}
-            <span class="badge">ativa</span>
+        <div class="card chart-card">
+          <div class="chart-head">
+            <div>
+              <p class="chart-title">Chamadas de API no mês</p>
+              <p class="chart-caption muted">Total de chamadas vs. bem-sucedidas, por dia</p>
+            </div>
+            <ul class="chart-legend" aria-hidden="true">
+              <li><span class="dot dot-total"></span>Total</li>
+              <li><span class="dot dot-success"></span>Bem-sucedidas</li>
+            </ul>
+          </div>
+
+          {% if chart.has_data %}
+          <div class="chart-wrap">
+            <svg class="usage-chart" viewBox="0 0 {{ chart.width }} {{ chart.height }}"
+                 role="img" preserveAspectRatio="none"
+                 aria-label="Gráfico de chamadas de API por dia nos últimos {{ analytics.window_days }} dias. Total de {{ analytics.total_requests }} chamadas, {{ analytics.successful_requests }} bem-sucedidas.">
+              <!-- gridlines + rótulos do eixo Y -->
+              {% for t in chart.y_ticks %}
+              <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ chart.width - 12 }}" y2="{{ t.pos }}"/>
+              <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
+              {% endfor %}
+              <!-- áreas -->
+              <path class="chart-area chart-area-total" d="{{ chart.total_area }}"/>
+              <path class="chart-area chart-area-success" d="{{ chart.success_area }}"/>
+              <!-- linhas -->
+              <polyline class="chart-line chart-line-total" points="{{ chart.total_line }}"/>
+              <polyline class="chart-line chart-line-success" points="{{ chart.success_line }}"/>
+              <!-- rótulos do eixo X -->
+              {% for t in chart.x_ticks %}
+              <text class="chart-axis" x="{{ t.pos }}" y="{{ chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
+              {% endfor %}
+              <!-- pontos (hover) -->
+              {% for p in chart.points %}
+              <circle class="chart-dot chart-dot-total" cx="{{ p.x }}" cy="{{ p.y_total }}" r="2.5"
+                      data-label="{{ p.label }}" data-total="{{ p.total }}" data-success="{{ p.successful }}"/>
+              {% endfor %}
+            </svg>
+            <div class="chart-tip" role="status" aria-live="off" hidden></div>
+          </div>
+
+          <details class="chart-data">
+            <summary>Ver dados em tabela</summary>
+            <div class="table-wrap">
+              <table>
+                <thead><tr><th scope="col">Dia</th><th scope="col">Total</th><th scope="col">Bem-sucedidas</th></tr></thead>
+                <tbody>
+                  {% for p in chart.points %}
+                  <tr><td data-label="Dia">{{ p.label }}</td><td data-label="Total">{{ p.total }}</td><td data-label="Bem-sucedidas">{{ p.successful }}</td></tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </details>
           {% else %}
-            <span class="badge badge-muted">revogada</span>
+          <div class="empty-state chart-empty">
+            <p><strong>Sem chamadas ainda.</strong></p>
+            <p class="muted">Assim que suas API keys começarem a receber chamadas, o consumo aparecerá aqui — veja o <a href="/guia">guia de início rápido</a>.</p>
+          </div>
           {% endif %}
-        </td>
-        <td data-label="Criada">{{ k.created_at.strftime('%d/%m/%Y') }}</td>
-        <td data-label="Último uso">{{ k.last_used_at.strftime('%d/%m/%Y %H:%M') if k.last_used_at else '—' }}</td>
-        <td class="cell-actions">
-          {% if k.status.value == 'active' %}
-          <form method="post" action="/portal/keys/{{ k.id }}/revoke" class="inline-form"
-                onsubmit="return confirm('Revogar a key “{{ k.name }}”? Aplicações que a usam perderão acesso imediatamente.');">
-            <button class="btn btn-danger btn-sm" type="submit">Revogar</button>
-          </form>
+        </div>
+
+        <!-- KPIs -->
+        <div class="grid kpi-grid">
+          <div class="card kpi">
+            <p class="kpi-label">Requisições ({{ analytics.window_days }} dias)</p>
+            <p class="kpi-value">{{ "{:,}".format(analytics.total_requests).replace(",", ".") }}</p>
+            {% if delta is not none %}
+            <p class="kpi-delta {{ 'is-up' if delta >= 0 else 'is-down' }}">
+              {{ "%+.0f"|format(delta) }}% vs. período anterior
+            </p>
+            {% else %}
+            <p class="kpi-delta muted">sem base de comparação</p>
+            {% endif %}
+          </div>
+
+          <div class="card kpi">
+            <p class="kpi-label">Taxa de sucesso</p>
+            <p class="kpi-value">
+              {% if analytics.success_rate is not none %}{{ "%.1f"|format(analytics.success_rate * 100) }}%{% else %}—{% endif %}
+            </p>
+            {% if analytics.success_rate is not none %}
+            <div class="kpi-meter" aria-hidden="true">
+              <span style="width: {{ (analytics.success_rate * 100)|round(1) }}%"></span>
+            </div>
+            <p class="kpi-delta muted">{{ analytics.failed_requests }} com erro no período</p>
+            {% else %}
+            <p class="kpi-delta muted">sem chamadas no período</p>
+            {% endif %}
+          </div>
+
+          <div class="card kpi">
+            <p class="kpi-label">Chamadas de IA ({{ analytics.window_days }} dias)</p>
+            <p class="kpi-value">{{ "{:,}".format(analytics.ai_requests).replace(",", ".") }}</p>
+            <p class="kpi-delta muted">{{ "{:,}".format(analytics.deterministic_requests).replace(",", ".") }} determinísticas</p>
+          </div>
+
+          <div class="card kpi">
+            <p class="kpi-label">Keys ativas</p>
+            <p class="kpi-value">{{ analytics.active_keys }}</p>
+            {% if analytics.new_keys_last_7d > 0 %}
+            <p class="kpi-delta is-up">+{{ analytics.new_keys_last_7d }} nos últimos 7 dias</p>
+            {% else %}
+            <p class="kpi-delta muted">nenhuma nova esta semana</p>
+            {% endif %}
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== API Keys ===================== -->
+      <section id="keys" aria-labelledby="keys-title">
+        <h2 id="keys-title" class="dash-section-title">API keys</h2>
+
+        {% if account.email_verified %}
+        <form method="post" action="/portal/keys" class="card key-form">
+          <label for="name">Nome da nova key</label>
+          <div class="key-form-row">
+            <input id="name" name="name" type="text" maxlength="120" required
+                   placeholder="ex.: integração-escola" aria-describedby="key-name-help">
+            <button class="btn" type="submit">Gerar nova key</button>
+          </div>
+          <p class="form-help" id="key-name-help">Um nome descritivo ajuda a saber o que revogar depois.</p>
+        </form>
+        {% endif %}
+
+        {% if keys %}
+        <div class="table-wrap">
+        <table class="keys-table">
+          <thead>
+            <tr>
+              <th scope="col">Nome</th>
+              <th scope="col">Prefixo</th>
+              <th scope="col">Status</th>
+              <th scope="col">Criação</th>
+              <th scope="col">Último uso</th>
+              <th scope="col"><span class="sr-only">Ações</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for k in keys %}
+            <tr>
+              <td data-label="Nome">{{ k.name }}</td>
+              <td data-label="Prefixo"><code>{{ k.prefix }}</code></td>
+              <td data-label="Status">
+                {% if k.status.value == 'active' %}
+                  <span class="pill pill-ok">ativa</span>
+                {% else %}
+                  <span class="pill pill-muted">revogada</span>
+                {% endif %}
+              </td>
+              <td data-label="Criação">{{ k.created_at.strftime('%d/%m/%Y') }}</td>
+              <td data-label="Último uso">{{ k.last_used_at.strftime('%d/%m/%Y %H:%M') if k.last_used_at else '—' }}</td>
+              <td class="cell-actions">
+                {% if k.status.value == 'active' %}
+                <form method="post" action="/portal/keys/{{ k.id }}/revoke" class="inline-form"
+                      onsubmit="return confirm('Revogar a key “{{ k.name }}”? Aplicações que a usam perderão acesso imediatamente.');">
+                  <button class="btn btn-danger btn-sm" type="submit">
+                    <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+                    Revogar
+                  </button>
+                </form>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        </div>
+        {% else %}
+        <div class="empty-state">
+          <p><strong>Nenhuma API key ainda.</strong></p>
+          {% if account.email_verified %}
+          <p class="muted">Gere a primeira no formulário acima e faça sua primeira chamada em minutos — o <a href="/guia">guia de início rápido</a> mostra como.</p>
+          {% else %}
+          <p class="muted">Verifique seu e-mail para liberar a geração de keys.</p>
           {% endif %}
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+        </div>
+        {% endif %}
+      </section>
+    </div>
   </div>
-  {% else %}
-  <div class="empty-state">
-    <p><strong>Nenhuma API key ainda.</strong></p>
-    {% if account.email_verified %}
-    <p class="muted">Gere a primeira no formulário acima e faça sua primeira chamada em minutos — o <a href="/guia">guia de início rápido</a> mostra como.</p>
-    {% else %}
-    <p class="muted">Verifique seu e-mail para liberar a geração de keys.</p>
-    {% endif %}
-  </div>
-  {% endif %}
 </div>
+
+{% if chart.has_data %}
+<script>
+  // Tooltip do gráfico de área (progressive enhancement: sem JS, os dados seguem
+  // acessíveis em "Ver dados em tabela"). Posiciona um balão sobre o ponto ativo.
+  (function () {
+    var wrap = document.querySelector(".chart-wrap");
+    if (!wrap) return;
+    var svg = wrap.querySelector(".usage-chart");
+    var tip = wrap.querySelector(".chart-tip");
+    var dots = wrap.querySelectorAll(".chart-dot-total");
+    if (!svg || !tip || !dots.length) return;
+
+    function show(dot) {
+      var label = dot.getAttribute("data-label");
+      var total = dot.getAttribute("data-total");
+      var success = dot.getAttribute("data-success");
+      tip.innerHTML = '<strong>' + label + '</strong>' +
+        '<span><i class="dot dot-total"></i>Total: ' + total + '</span>' +
+        '<span><i class="dot dot-success"></i>Bem-sucedidas: ' + success + '</span>';
+      tip.hidden = false;
+      // Converte coordenada do viewBox para pixel do container.
+      var rect = svg.getBoundingClientRect();
+      var vb = svg.viewBox.baseVal;
+      var px = (parseFloat(dot.getAttribute("cx")) / vb.width) * rect.width;
+      var py = (parseFloat(dot.getAttribute("cy")) / vb.height) * rect.height;
+      tip.style.left = px + "px";
+      tip.style.top = py + "px";
+      dot.classList.add("is-active");
+    }
+    function hide(dot) { tip.hidden = true; dot.classList.remove("is-active"); }
+
+    dots.forEach(function (dot) {
+      dot.addEventListener("mouseenter", function () { show(dot); });
+      dot.addEventListener("mouseleave", function () { hide(dot); });
+      dot.addEventListener("focus", function () { show(dot); });
+      dot.addEventListener("blur", function () { hide(dot); });
+      dot.setAttribute("tabindex", "0");
+    });
+  })();
+</script>
+{% endif %}
 
 {% if new_key %}
 {# Modal de revelação única da key. O segredo NÃO é persistido nem re-renderizado:
@@ -200,8 +384,6 @@
     modal.querySelectorAll("[data-close-key-modal]").forEach(function (b) {
       b.addEventListener("click", closeModal);
     });
-    // Impede fechar por Esc sem confirmar leitura: reabre? Não — permitimos Esc,
-    // mas garantimos limpeza do segredo.
     modal.addEventListener("cancel", function () { if (input) input.value = ""; modal.remove(); });
   })();
 </script>

--- a/app/web/templates/portal/forgot_password.html
+++ b/app/web/templates/portal/forgot_password.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% block title %}Recuperar senha — BNCC API{% endblock %}
+{% block description %}Recupere o acesso ao portal da BNCC API: informe seu e-mail e enviaremos um link para redefinir sua senha.{% endblock %}
+{% block robots %}<meta name="robots" content="noindex">{% endblock %}
+
+{% block content %}
+<div class="container section auth-wrap">
+  <span class="auth-mark" aria-hidden="true">
+    <svg viewBox="0 0 48 48" width="42" height="42" focusable="false">
+      <defs>
+        <linearGradient id="auth-tile" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="#1b4dff"/>
+          <stop offset="1" stop-color="#0aa8dc"/>
+        </linearGradient>
+      </defs>
+      <rect x="4" y="4" width="40" height="40" rx="12" fill="url(#auth-tile)"/>
+      <g fill="none" stroke="#ffffff" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M13 22l11 4.5L35 22"/><path d="M13 28.6l11 4.5 11-4.5"/><path d="M13 35.2l11 4.5 11-4.5"/>
+      </g>
+      <circle cx="24" cy="13.8" r="3.3" fill="#ffc53d"/>
+    </svg>
+  </span>
+  <h1>Recuperar senha</h1>
+  <p class="lead">Informe o e-mail da sua conta e enviaremos um link para criar uma nova senha.</p>
+
+  {% if info %}<div class="notice" role="status">{{ info }}</div>{% endif %}
+
+  <div class="card auth-card">
+    <form method="post" action="/portal/forgot-password" class="auth-form">
+      <label for="email">E-mail</label>
+      <input id="email" name="email" type="email" autocomplete="email" required
+             inputmode="email" placeholder="voce@exemplo.com">
+      <div class="form-actions">
+        <button class="btn btn-block" type="submit">Enviar link de redefinição</button>
+      </div>
+    </form>
+  </div>
+
+  <p class="form-footer">
+    Lembrou a senha? <a href="/portal/login">Voltar para o login</a>
+  </p>
+</div>
+{% endblock %}

--- a/app/web/templates/portal/reset_password.html
+++ b/app/web/templates/portal/reset_password.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Entrar no portal — BNCC API{% endblock %}
-{% block description %}Acesse o portal da BNCC API para gerar e revogar API keys e acompanhar seu consumo — tudo
-self-service e gratuito.{% endblock %}
+{% block title %}Redefinir senha — BNCC API{% endblock %}
+{% block description %}Crie uma nova senha para sua conta da BNCC API.{% endblock %}
 {% block robots %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block content %}
@@ -17,46 +16,43 @@ self-service e gratuito.{% endblock %}
       </defs>
       <rect x="4" y="4" width="40" height="40" rx="12" fill="url(#auth-tile)"/>
       <g fill="none" stroke="#ffffff" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M13 22l11 4.5L35 22"/>
-        <path d="M13 28.6l11 4.5 11-4.5"/>
-        <path d="M13 35.2l11 4.5 11-4.5"/>
+        <path d="M13 22l11 4.5L35 22"/><path d="M13 28.6l11 4.5 11-4.5"/><path d="M13 35.2l11 4.5 11-4.5"/>
       </g>
       <circle cx="24" cy="13.8" r="3.3" fill="#ffc53d"/>
     </svg>
   </span>
-  <h1>Entre no portal</h1>
-  <p class="lead">Gerencie suas API keys e acompanhe o consumo.</p>
+  <h1>Criar nova senha</h1>
+  <p class="lead">Escolha uma senha com no mínimo 10 caracteres, contendo letras e números.</p>
 
-  {% if info %}<div class="notice" role="status">{{ info }}</div>{% endif %}
   {% if error %}<div class="notice notice-danger" role="alert">{{ error }}</div>{% endif %}
 
   <div class="card auth-card">
-    {% with cta="entre" %}{% include "portal/_oauth_buttons.html" %}{% endwith %}
+    <form method="post" action="/portal/reset-password" class="auth-form">
+      <input type="hidden" name="token" value="{{ token }}">
 
-    <form method="post" action="/portal/login" class="auth-form">
-      <label for="email">E-mail</label>
-      <input id="email" name="email" type="email" autocomplete="email" required>
-
-      <label for="password">Senha</label>
+      <label for="new_password">Nova senha</label>
       <div class="input-affix">
-        <input id="password" name="password" type="password" autocomplete="current-password" required>
-        <button type="button" class="input-affix-btn" data-toggle-password="password" aria-label="Mostrar senha" aria-pressed="false"><!-- pragma: allowlist secret -->
+        <input id="new_password" name="new_password" type="password" autocomplete="new-password"
+               minlength="10" required aria-describedby="pw-help">
+        <button type="button" class="input-affix-btn" data-toggle-password="new_password" aria-label="Mostrar senha" aria-pressed="false"><!-- pragma: allowlist secret -->
           <svg class="icon-eye" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
           <svg class="icon-eye-off" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c6.5 0 10 8 10 8a18.5 18.5 0 0 1-2.16 3.19M6.61 6.61A18.5 18.5 0 0 0 2 12s3.5 7 10 7a9.12 9.12 0 0 0 5.39-1.61"/><path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/><path d="m2 2 20 20"/></svg>
         </button>
       </div>
+      <p class="form-help" id="pw-help">Mín. 10 caracteres, com letras e números.</p>
+
+      <label for="confirm_password">Confirmar nova senha</label>
+      <input id="confirm_password" name="confirm_password" type="password" autocomplete="new-password"
+             minlength="10" required>
 
       <div class="form-actions">
-        <button class="btn btn-block" type="submit">Entrar</button>
-        <p class="form-help form-help-right">
-          <a href="/portal/forgot-password">Esqueci minha senha</a>
-        </p>
+        <button class="btn btn-block" type="submit">Redefinir senha</button>
       </div>
     </form>
   </div>
 
   <p class="form-footer">
-    Ainda não tem conta? <a href="/portal/signup">Crie a sua grátis</a>
+    <a href="/portal/login">Voltar para o login</a>
   </p>
 </div>
 {% endblock %}

--- a/docs/openapi/v1/1.3.0.json
+++ b/docs/openapi/v1/1.3.0.json
@@ -1,6 +1,101 @@
 {
   "components": {
     "schemas": {
+      "AccountAnalyticsResponse": {
+        "description": "BI de uso da conta: série diária + KPIs agregados da janela (30 dias).",
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "string"
+          },
+          "active_keys": {
+            "title": "Active Keys",
+            "type": "integer"
+          },
+          "ai_requests": {
+            "description": "Chamadas de IA na janela",
+            "title": "Ai Requests",
+            "type": "integer"
+          },
+          "deterministic_requests": {
+            "description": "Chamadas determinísticas na janela",
+            "title": "Deterministic Requests",
+            "type": "integer"
+          },
+          "failed_requests": {
+            "title": "Failed Requests",
+            "type": "integer"
+          },
+          "new_keys_last_7d": {
+            "description": "Keys ativas criadas nos últimos 7 dias",
+            "title": "New Keys Last 7D",
+            "type": "integer"
+          },
+          "series": {
+            "items": {
+              "$ref": "#/components/schemas/UsageDailyPoint"
+            },
+            "title": "Series",
+            "type": "array"
+          },
+          "success_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "successful/total na janela; nulo quando não houve tráfego",
+            "title": "Success Rate"
+          },
+          "successful_requests": {
+            "title": "Successful Requests",
+            "type": "integer"
+          },
+          "total_requests": {
+            "title": "Total Requests",
+            "type": "integer"
+          },
+          "total_requests_delta_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Variação % vs. janela anterior; nulo quando a anterior foi zero",
+            "title": "Total Requests Delta Pct"
+          },
+          "total_requests_prev": {
+            "description": "Total da janela anterior (para o delta)",
+            "title": "Total Requests Prev",
+            "type": "integer"
+          },
+          "window_days": {
+            "title": "Window Days",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "account_id",
+          "window_days",
+          "series",
+          "total_requests",
+          "successful_requests",
+          "failed_requests",
+          "total_requests_prev",
+          "ai_requests",
+          "deterministic_requests",
+          "active_keys",
+          "new_keys_last_7d"
+        ],
+        "title": "AccountAnalyticsResponse",
+        "type": "object"
+      },
       "AccountMe": {
         "properties": {
           "account_id": {
@@ -142,6 +237,29 @@
         "title": "AreaConhecimento",
         "type": "string"
       },
+      "Body_change_password_submit_portal_account_password_post": {
+        "properties": {
+          "confirm_password": {
+            "title": "Confirm Password",
+            "type": "string"
+          },
+          "current_password": {
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_password": {
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_password",
+          "confirm_password"
+        ],
+        "title": "Body_change_password_submit_portal_account_password_post",
+        "type": "object"
+      },
       "Body_dashboard_create_key_portal_keys_post": {
         "properties": {
           "name": {
@@ -153,6 +271,19 @@
           "name"
         ],
         "title": "Body_dashboard_create_key_portal_keys_post",
+        "type": "object"
+      },
+      "Body_forgot_password_submit_portal_forgot_password_post": {
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "Body_forgot_password_submit_portal_forgot_password_post",
         "type": "object"
       },
       "Body_login_submit_portal_login_post": {
@@ -192,6 +323,29 @@
           "step"
         ],
         "title": "Body_onboarding_submit_portal_onboarding_post",
+        "type": "object"
+      },
+      "Body_reset_password_submit_portal_reset_password_post": {
+        "properties": {
+          "confirm_password": {
+            "title": "Confirm Password",
+            "type": "string"
+          },
+          "new_password": {
+            "title": "New Password",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "new_password",
+          "confirm_password"
+        ],
+        "title": "Body_reset_password_submit_portal_reset_password_post",
         "type": "object"
       },
       "Body_signup_submit_portal_signup_post": {
@@ -354,6 +508,26 @@
           "resposta"
         ],
         "title": "BuscaSemanticaResponse",
+        "type": "object"
+      },
+      "ChangePasswordRequest": {
+        "properties": {
+          "current_password": {
+            "description": "Senha atual da conta",
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_password": {
+            "description": "Nova senha: mín. 10 caracteres, com letras e números",
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_password"
+        ],
+        "title": "ChangePasswordRequest",
         "type": "object"
       },
       "CompetenciaEspecifica": {
@@ -578,6 +752,20 @@
         "title": "EtapaEnsino",
         "type": "string"
       },
+      "ForgotPasswordRequest": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "ForgotPasswordRequest",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -792,6 +980,20 @@
         "title": "LoginResponse",
         "type": "object"
       },
+      "MessageResponse": {
+        "description": "Resposta neutra e genérica (usada em fluxos anti-enumeração).",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "MessageResponse",
+        "type": "object"
+      },
       "PaginatedResponse": {
         "description": "Resposta paginada genérica.",
         "example": {
@@ -837,6 +1039,26 @@
           "pages"
         ],
         "title": "PaginatedResponse",
+        "type": "object"
+      },
+      "ResetPasswordRequest": {
+        "properties": {
+          "new_password": {
+            "description": "Nova senha: mín. 10 caracteres, com letras e números",
+            "title": "New Password",
+            "type": "string"
+          },
+          "token": {
+            "minLength": 8,
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "new_password"
+        ],
+        "title": "ResetPasswordRequest",
         "type": "object"
       },
       "SignupRequest": {
@@ -924,6 +1146,39 @@
           "data_publicacao"
         ],
         "title": "SnapshotMetadata",
+        "type": "object"
+      },
+      "UsageDailyPoint": {
+        "description": "Um ponto da série diária do painel (um dia do calendário UTC).",
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "failed": {
+            "description": "Chamadas com desfecho de erro (>= 400)",
+            "title": "Failed",
+            "type": "integer"
+          },
+          "successful": {
+            "description": "Chamadas com desfecho de sucesso (< 400)",
+            "title": "Successful",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Chamadas autorizadas no dia (qualquer desfecho)",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "date",
+          "total",
+          "successful",
+          "failed"
+        ],
+        "title": "UsageDailyPoint",
         "type": "object"
       },
       "ValidationError": {
@@ -1024,6 +1279,142 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/auth/change-password": {
+      "post": {
+        "description": "Troca a senha da conta associada à sessão atual, exigindo a senha atual. A nova senha deve seguir a política (mín. 10 caracteres, com letras e números). Contas criadas apenas por login social não possuem senha atual — use o fluxo de redefinição para definir uma.",
+        "operationId": "change_password_api_v1_auth_change_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "padrao": {
+                  "summary": "Troca de senha",
+                  "value": {
+                    "current_password": "SenhaForte123",
+                    "new_password": "NovaSenha456"
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Confirmação de que a senha foi alterada."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Senha atual incorreta ou nova senha inválida."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Sessão ausente, inválida ou expirada."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "summary": "Trocar a senha da conta autenticada",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/api/v1/auth/forgot-password": {
+      "post": {
+        "description": "Dispara um e-mail com um link de redefinição de senha de uso único, quando existe uma conta para o e-mail informado. Para preservar a privacidade (anti-enumeração — Princípio V), a resposta é idêntica exista ou não a conta.",
+        "operationId": "forgot_password_api_v1_auth_forgot_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "padrao": {
+                  "summary": "Pedido de reset",
+                  "value": {
+                    "email": "dev@example.com"
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ForgotPasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Resposta neutra: sempre a mesma, exista ou não a conta."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Muitas solicitações deste IP."
+          }
+        },
+        "summary": "Solicitar redefinição de senha",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
     "/api/v1/auth/login": {
       "post": {
         "description": "Autentica com e-mail/senha e retorna um JWT de sessão do portal (também definido como cookie httponly `session`). Falha de credencial ou e-mail não verificado retornam a mesma mensagem (anti-enumeração — Princípio V / FR-023).",
@@ -1153,6 +1544,77 @@
           }
         ],
         "summary": "Dados da conta autenticada",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/api/v1/auth/reset-password": {
+      "post": {
+        "description": "Consome o token de uso único enviado por e-mail e grava a nova senha (seguindo a política). Possuir o link comprova controle do e-mail, então a conta é marcada como verificada.",
+        "operationId": "reset_password_api_v1_auth_reset_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "padrao": {
+                  "summary": "Redefinição",
+                  "value": {
+                    "new_password": "NovaSenha456",
+                    "token": "a1b2c3d4e5f6"
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Confirmação de que a senha foi redefinida."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Token inválido ou nova senha fora da política."
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Token expirado ou já utilizado."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Redefinir a senha com o token do e-mail",
         "tags": [
           "Autenticação"
         ]
@@ -2446,6 +2908,44 @@
           }
         ],
         "summary": "Uso agregado da conta",
+        "tags": [
+          "Uso",
+          "Uso"
+        ]
+      }
+    },
+    "/api/v1/usage/analytics": {
+      "get": {
+        "description": "Retorna o BI de uso da conta autenticada: uma série diária dos últimos 30 dias (chamadas totais vs. bem-sucedidas) e indicadores agregados para o painel do portal (total de requisições com variação vs. período anterior, taxa de sucesso, chamadas de IA e determinísticas, keys ativas e novas). Exige sessão do portal.",
+        "operationId": "account_analytics_api_v1_usage_analytics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountAnalyticsResponse"
+                }
+              }
+            },
+            "description": "Série diária dos últimos 30 dias (total vs. bem-sucedidas) e KPIs agregados: total de requisições e variação, taxa de sucesso, uso de IA, keys ativas."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Sessão ausente, inválida ou expirada."
+          }
+        },
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "summary": "Analytics de uso da conta (série diária + KPIs)",
         "tags": [
           "Uso",
           "Uso"

--- a/migrations/versions/0004_usage_error_count.py
+++ b/migrations/versions/0004_usage_error_count.py
@@ -1,0 +1,36 @@
+"""usage_records: coluna error_count (chamadas com desfecho de erro por dia)
+
+Aditivo: ``count`` segue sendo o total de chamadas autorizadas do dia e
+``error_count`` passa a registrar o subconjunto que terminou em erro (>= 400).
+Taxa de sucesso do painel = (count - error_count) / count. Não altera a
+UniqueConstraint existente (por isso não exige batch mode para recriá-la).
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-07-09
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "usage_records",
+        sa.Column("error_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    # Remove o server_default depois do backfill: o default de aplicação (0) passa
+    # a valer para novas linhas, mantendo o schema alinhado ao ORM.
+    with op.batch_alter_table("usage_records") as batch_op:
+        batch_op.alter_column("error_count", server_default=None)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("usage_records") as batch_op:
+        batch_op.drop_column("error_count")

--- a/migrations/versions/0005_password_reset_tokens.py
+++ b/migrations/versions/0005_password_reset_tokens.py
@@ -1,0 +1,51 @@
+"""password_reset_tokens (fluxo "esqueci a senha")
+
+Token de uso único para redefinição de senha, espelhando
+``email_verification_tokens``: só o hash SHA-256 é persistido, com expiração e
+invalidação após o uso. Anti-enumeração no serviço (não cria registro para
+e-mail inexistente).
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-07-09
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("account_id", sa.String(length=36), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["account_id"], ["developer_accounts.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_password_reset_tokens_account_id",
+        "password_reset_tokens",
+        ["account_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_password_reset_tokens_token_hash",
+        "password_reset_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_password_reset_tokens_token_hash", table_name="password_reset_tokens")
+    op.drop_index("ix_password_reset_tokens_account_id", table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def _reset_rate_limiters():
     from app.core.deps import (
         ai_limiter,
         deterministic_limiter,
+        forgot_ip_limiter,
         login_ip_limiter,
         oauth_ip_limiter,
         signup_ip_limiter,
@@ -58,6 +59,7 @@ def _reset_rate_limiters():
     signup_ip_limiter.reset()
     verify_ip_limiter.reset()
     oauth_ip_limiter.reset()
+    forgot_ip_limiter.reset()
     yield
 
 

--- a/tests/contract/openapi_snapshot.json
+++ b/tests/contract/openapi_snapshot.json
@@ -1,6 +1,101 @@
 {
   "components": {
     "schemas": {
+      "AccountAnalyticsResponse": {
+        "description": "BI de uso da conta: série diária + KPIs agregados da janela (30 dias).",
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "string"
+          },
+          "active_keys": {
+            "title": "Active Keys",
+            "type": "integer"
+          },
+          "ai_requests": {
+            "description": "Chamadas de IA na janela",
+            "title": "Ai Requests",
+            "type": "integer"
+          },
+          "deterministic_requests": {
+            "description": "Chamadas determinísticas na janela",
+            "title": "Deterministic Requests",
+            "type": "integer"
+          },
+          "failed_requests": {
+            "title": "Failed Requests",
+            "type": "integer"
+          },
+          "new_keys_last_7d": {
+            "description": "Keys ativas criadas nos últimos 7 dias",
+            "title": "New Keys Last 7D",
+            "type": "integer"
+          },
+          "series": {
+            "items": {
+              "$ref": "#/components/schemas/UsageDailyPoint"
+            },
+            "title": "Series",
+            "type": "array"
+          },
+          "success_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "successful/total na janela; nulo quando não houve tráfego",
+            "title": "Success Rate"
+          },
+          "successful_requests": {
+            "title": "Successful Requests",
+            "type": "integer"
+          },
+          "total_requests": {
+            "title": "Total Requests",
+            "type": "integer"
+          },
+          "total_requests_delta_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Variação % vs. janela anterior; nulo quando a anterior foi zero",
+            "title": "Total Requests Delta Pct"
+          },
+          "total_requests_prev": {
+            "description": "Total da janela anterior (para o delta)",
+            "title": "Total Requests Prev",
+            "type": "integer"
+          },
+          "window_days": {
+            "title": "Window Days",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "account_id",
+          "window_days",
+          "series",
+          "total_requests",
+          "successful_requests",
+          "failed_requests",
+          "total_requests_prev",
+          "ai_requests",
+          "deterministic_requests",
+          "active_keys",
+          "new_keys_last_7d"
+        ],
+        "title": "AccountAnalyticsResponse",
+        "type": "object"
+      },
       "AccountMe": {
         "properties": {
           "account_id": {
@@ -142,6 +237,29 @@
         "title": "AreaConhecimento",
         "type": "string"
       },
+      "Body_change_password_submit_portal_account_password_post": {
+        "properties": {
+          "confirm_password": {
+            "title": "Confirm Password",
+            "type": "string"
+          },
+          "current_password": {
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_password": {
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_password",
+          "confirm_password"
+        ],
+        "title": "Body_change_password_submit_portal_account_password_post",
+        "type": "object"
+      },
       "Body_dashboard_create_key_portal_keys_post": {
         "properties": {
           "name": {
@@ -153,6 +271,19 @@
           "name"
         ],
         "title": "Body_dashboard_create_key_portal_keys_post",
+        "type": "object"
+      },
+      "Body_forgot_password_submit_portal_forgot_password_post": {
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "Body_forgot_password_submit_portal_forgot_password_post",
         "type": "object"
       },
       "Body_login_submit_portal_login_post": {
@@ -192,6 +323,29 @@
           "step"
         ],
         "title": "Body_onboarding_submit_portal_onboarding_post",
+        "type": "object"
+      },
+      "Body_reset_password_submit_portal_reset_password_post": {
+        "properties": {
+          "confirm_password": {
+            "title": "Confirm Password",
+            "type": "string"
+          },
+          "new_password": {
+            "title": "New Password",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "new_password",
+          "confirm_password"
+        ],
+        "title": "Body_reset_password_submit_portal_reset_password_post",
         "type": "object"
       },
       "Body_signup_submit_portal_signup_post": {
@@ -354,6 +508,26 @@
           "resposta"
         ],
         "title": "BuscaSemanticaResponse",
+        "type": "object"
+      },
+      "ChangePasswordRequest": {
+        "properties": {
+          "current_password": {
+            "description": "Senha atual da conta",
+            "title": "Current Password",
+            "type": "string"
+          },
+          "new_password": {
+            "description": "Nova senha: mín. 10 caracteres, com letras e números",
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_password",
+          "new_password"
+        ],
+        "title": "ChangePasswordRequest",
         "type": "object"
       },
       "CompetenciaEspecifica": {
@@ -578,6 +752,20 @@
         "title": "EtapaEnsino",
         "type": "string"
       },
+      "ForgotPasswordRequest": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "ForgotPasswordRequest",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -792,6 +980,20 @@
         "title": "LoginResponse",
         "type": "object"
       },
+      "MessageResponse": {
+        "description": "Resposta neutra e genérica (usada em fluxos anti-enumeração).",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "MessageResponse",
+        "type": "object"
+      },
       "PaginatedResponse": {
         "description": "Resposta paginada genérica.",
         "example": {
@@ -837,6 +1039,26 @@
           "pages"
         ],
         "title": "PaginatedResponse",
+        "type": "object"
+      },
+      "ResetPasswordRequest": {
+        "properties": {
+          "new_password": {
+            "description": "Nova senha: mín. 10 caracteres, com letras e números",
+            "title": "New Password",
+            "type": "string"
+          },
+          "token": {
+            "minLength": 8,
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "new_password"
+        ],
+        "title": "ResetPasswordRequest",
         "type": "object"
       },
       "SignupRequest": {
@@ -924,6 +1146,39 @@
           "data_publicacao"
         ],
         "title": "SnapshotMetadata",
+        "type": "object"
+      },
+      "UsageDailyPoint": {
+        "description": "Um ponto da série diária do painel (um dia do calendário UTC).",
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "failed": {
+            "description": "Chamadas com desfecho de erro (>= 400)",
+            "title": "Failed",
+            "type": "integer"
+          },
+          "successful": {
+            "description": "Chamadas com desfecho de sucesso (< 400)",
+            "title": "Successful",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Chamadas autorizadas no dia (qualquer desfecho)",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "date",
+          "total",
+          "successful",
+          "failed"
+        ],
+        "title": "UsageDailyPoint",
         "type": "object"
       },
       "ValidationError": {
@@ -1024,6 +1279,142 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/auth/change-password": {
+      "post": {
+        "description": "Troca a senha da conta associada à sessão atual, exigindo a senha atual. A nova senha deve seguir a política (mín. 10 caracteres, com letras e números). Contas criadas apenas por login social não possuem senha atual — use o fluxo de redefinição para definir uma.",
+        "operationId": "change_password_api_v1_auth_change_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "padrao": {
+                  "summary": "Troca de senha",
+                  "value": {
+                    "current_password": "SenhaForte123",
+                    "new_password": "NovaSenha456"
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Confirmação de que a senha foi alterada."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Senha atual incorreta ou nova senha inválida."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Sessão ausente, inválida ou expirada."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "summary": "Trocar a senha da conta autenticada",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/api/v1/auth/forgot-password": {
+      "post": {
+        "description": "Dispara um e-mail com um link de redefinição de senha de uso único, quando existe uma conta para o e-mail informado. Para preservar a privacidade (anti-enumeração — Princípio V), a resposta é idêntica exista ou não a conta.",
+        "operationId": "forgot_password_api_v1_auth_forgot_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "padrao": {
+                  "summary": "Pedido de reset",
+                  "value": {
+                    "email": "dev@example.com"
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ForgotPasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Resposta neutra: sempre a mesma, exista ou não a conta."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Muitas solicitações deste IP."
+          }
+        },
+        "summary": "Solicitar redefinição de senha",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
     "/api/v1/auth/login": {
       "post": {
         "description": "Autentica com e-mail/senha e retorna um JWT de sessão do portal (também definido como cookie httponly `session`). Falha de credencial ou e-mail não verificado retornam a mesma mensagem (anti-enumeração — Princípio V / FR-023).",
@@ -1153,6 +1544,77 @@
           }
         ],
         "summary": "Dados da conta autenticada",
+        "tags": [
+          "Autenticação"
+        ]
+      }
+    },
+    "/api/v1/auth/reset-password": {
+      "post": {
+        "description": "Consome o token de uso único enviado por e-mail e grava a nova senha (seguindo a política). Possuir o link comprova controle do e-mail, então a conta é marcada como verificada.",
+        "operationId": "reset_password_api_v1_auth_reset_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "padrao": {
+                  "summary": "Redefinição",
+                  "value": {
+                    "new_password": "NovaSenha456",
+                    "token": "a1b2c3d4e5f6"
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            },
+            "description": "Confirmação de que a senha foi redefinida."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Token inválido ou nova senha fora da política."
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Token expirado ou já utilizado."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Redefinir a senha com o token do e-mail",
         "tags": [
           "Autenticação"
         ]
@@ -2446,6 +2908,44 @@
           }
         ],
         "summary": "Uso agregado da conta",
+        "tags": [
+          "Uso",
+          "Uso"
+        ]
+      }
+    },
+    "/api/v1/usage/analytics": {
+      "get": {
+        "description": "Retorna o BI de uso da conta autenticada: uma série diária dos últimos 30 dias (chamadas totais vs. bem-sucedidas) e indicadores agregados para o painel do portal (total de requisições com variação vs. período anterior, taxa de sucesso, chamadas de IA e determinísticas, keys ativas e novas). Exige sessão do portal.",
+        "operationId": "account_analytics_api_v1_usage_analytics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountAnalyticsResponse"
+                }
+              }
+            },
+            "description": "Série diária dos últimos 30 dias (total vs. bem-sucedidas) e KPIs agregados: total de requisições e variação, taxa de sucesso, uso de IA, keys ativas."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Sessão ausente, inválida ou expirada."
+          }
+        },
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "summary": "Analytics de uso da conta (série diária + KPIs)",
         "tags": [
           "Uso",
           "Uso"

--- a/tests/contract/test_password.py
+++ b/tests/contract/test_password.py
@@ -1,0 +1,170 @@
+"""
+Testes de contrato da gestão de senha (trocar + esqueci/redefinir).
+
+Cobre ``/api/v1/auth/change-password``, ``/forgot-password`` e ``/reset-password``:
+formatos, autorização por sessão, política de senha e anti-enumeração.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from app.core.security import (
+    create_access_token,
+    hash_password,
+    hash_verification_token,
+)
+from app.db.tables import DeveloperAccount, PasswordResetToken
+from app.services import account_service
+
+
+def _session(account_id: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token(subject=account_id)}"}
+
+
+# --------------------------------------------------------------------------- #
+# Trocar senha (logado)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_change_password_happy(async_client, verified_account):
+    r = await async_client.post(
+        "/api/v1/auth/change-password",
+        headers=_session(verified_account.id),
+        json={"current_password": "senha-forte-123", "new_password": "NovaSenha456"},
+    )
+    assert r.status_code == 200, r.text
+
+    # A nova senha passa a valer; a antiga não.
+    ok = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": verified_account.email, "password": "NovaSenha456"},
+    )
+    assert ok.status_code == 200, ok.text
+    old = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": verified_account.email, "password": "senha-forte-123"},
+    )
+    assert old.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_change_password_wrong_current_400(async_client, verified_account):
+    r = await async_client.post(
+        "/api/v1/auth/change-password",
+        headers=_session(verified_account.id),
+        json={"current_password": "errada-000000", "new_password": "NovaSenha456"},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_change_password_weak_new_422(async_client, verified_account):
+    r = await async_client.post(
+        "/api/v1/auth/change-password",
+        headers=_session(verified_account.id),
+        json={"current_password": "senha-forte-123", "new_password": "curta"},
+    )
+    # O handler global normaliza erros de validação (Pydantic) para 400 (ver
+    # app/core/errors.py), como no signup.
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_change_password_requires_session_401(async_client, verified_account):
+    r = await async_client.post(
+        "/api/v1/auth/change-password",
+        json={"current_password": "senha-forte-123", "new_password": "NovaSenha456"},
+    )
+    assert r.status_code == 401
+
+
+# --------------------------------------------------------------------------- #
+# Esqueci a senha (anti-enumeração)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_forgot_password_is_neutral(async_client, verified_account):
+    exists = await async_client.post(
+        "/api/v1/auth/forgot-password", json={"email": verified_account.email}
+    )
+    missing = await async_client.post(
+        "/api/v1/auth/forgot-password", json={"email": "ninguem@example.com"}
+    )
+    assert exists.status_code == 200
+    assert missing.status_code == 200
+    # Corpo idêntico — não revela se a conta existe.
+    assert exists.json() == missing.json()
+
+
+# --------------------------------------------------------------------------- #
+# Redefinir senha (consumo do token)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_reset_password_happy(async_client, verified_account, db_session):
+    token = await account_service.request_password_reset(db_session, verified_account.email)
+    assert token  # emitido para conta existente
+
+    r = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": "OutraSenha789"},
+    )
+    assert r.status_code == 200, r.text
+
+    ok = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": verified_account.email, "password": "OutraSenha789"},
+    )
+    assert ok.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_reset_password_invalid_token_400(async_client, verified_account):
+    r = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": "nao-existe-token-000", "new_password": "OutraSenha789"},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reset_password_used_token_410(async_client, verified_account, db_session):
+    token = await account_service.request_password_reset(db_session, verified_account.email)
+    first = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": "OutraSenha789"},
+    )
+    assert first.status_code == 200
+    again = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": "MaisUmaSenha1"},
+    )
+    assert again.status_code == 410  # token de uso único já consumido
+
+
+@pytest.mark.asyncio
+async def test_reset_password_expired_token_410(async_client, db_session):
+    account = DeveloperAccount(
+        email="exp@example.com",
+        password_hash=hash_password("senha-forte-123"),
+        email_verified=True,
+    )
+    db_session.add(account)
+    await db_session.commit()
+    await db_session.refresh(account)
+
+    # Token com expiração no passado (fabricado direto no banco).
+    plain = "token-expirado-abcdef"
+    db_session.add(
+        PasswordResetToken(
+            account_id=account.id,
+            token_hash=hash_verification_token(plain),
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        )
+    )
+    await db_session.commit()
+
+    r = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": plain, "new_password": "OutraSenha789"},
+    )
+    assert r.status_code == 410

--- a/tests/contract/test_usage.py
+++ b/tests/contract/test_usage.py
@@ -97,3 +97,49 @@ async def test_deterministic_request_is_counted_in_portal(
     agg = await async_client.get("/api/v1/usage", headers=_session(verified_account.id))
     assert agg.status_code == 200, agg.text
     assert agg.json()["deterministic_used_today"] == 2
+
+
+@pytest.mark.asyncio
+async def test_account_analytics_shape(async_client, verified_account, api_key):
+    r = await async_client.get("/api/v1/usage/analytics", headers=_session(verified_account.id))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["account_id"] == verified_account.id
+    assert body["window_days"] == 30
+    assert len(body["series"]) == 30
+    # Sem tráfego: taxa de sucesso é nula (painel mostra "—", não 0%/100%).
+    assert body["success_rate"] is None
+    assert body["total_requests"] == 0
+    assert body["active_keys"] >= 1
+    # A série é ordenada e termina hoje.
+    assert body["series"][0]["date"] <= body["series"][-1]["date"]
+
+
+@pytest.mark.asyncio
+async def test_analytics_reflects_success_and_failure(
+    async_client, verified_account, api_key, auth_headers
+):
+    """Integração ponta a ponta: uma chamada OK e uma 404 alimentam o BI.
+
+    O ``UsageOutcomeMiddleware`` contabiliza o desfecho de erro (>= 400) da chamada
+    real (sem override), de modo que a taxa de sucesso e a série diária refletem
+    total=2, bem-sucedidas=1."""
+    # 1 chamada determinística bem-sucedida.
+    ok = await async_client.get("/api/v1/taxonomia", headers=auth_headers)
+    assert ok.status_code == 200, ok.text
+    # 1 chamada com formato válido mas código inexistente → 404.
+    missing = await async_client.get("/api/v1/habilidades/EF99ZZ99", headers=auth_headers)
+    assert missing.status_code == 404, missing.text
+
+    r = await async_client.get("/api/v1/usage/analytics", headers=_session(verified_account.id))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total_requests"] == 2
+    assert body["failed_requests"] == 1
+    assert body["successful_requests"] == 1
+    assert body["success_rate"] == 0.5
+    # O ponto de hoje (último da série) reflete os desfechos.
+    today = body["series"][-1]
+    assert today["total"] == 2
+    assert today["successful"] == 1
+    assert today["failed"] == 1

--- a/tests/integration/test_portal_password.py
+++ b/tests/integration/test_portal_password.py
@@ -1,0 +1,100 @@
+"""
+Cobertura SSR do painel redesenhado (BI) e dos fluxos de senha no portal.
+
+Exercita as páginas públicas (esqueci/redefinir), a troca de senha autenticada e
+a renderização do dashboard com a seção de analytics.
+"""
+
+VALID_PW = "senha-forte-123"  # pragma: allowlist secret
+
+
+# --------------------------------------------------------------------------- #
+# Páginas públicas de recuperação
+# --------------------------------------------------------------------------- #
+def test_forgot_password_page_renders(client):
+    r = client.get("/portal/forgot-password")
+    assert r.status_code == 200
+    assert "Recuperar senha" in r.text
+
+
+def test_forgot_password_submit_is_neutral(client):
+    r = client.post("/portal/forgot-password", data={"email": "ninguem@example.com"})
+    assert r.status_code == 200
+    assert "link de redefinição" in r.text.lower()
+
+
+def test_reset_password_page_requires_token(client):
+    r = client.get("/portal/reset-password")
+    assert r.status_code == 400
+
+
+def test_reset_password_page_with_token_renders(client):
+    r = client.get("/portal/reset-password?token=abc123def456")
+    assert r.status_code == 200
+    assert "Criar nova senha" in r.text
+
+
+def test_change_password_requires_session(client):
+    r = client.get("/portal/account/password", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"].endswith("/portal/login")
+
+
+# --------------------------------------------------------------------------- #
+# Fluxo autenticado
+# --------------------------------------------------------------------------- #
+def test_dashboard_renders_analytics(client, onboarded_account):
+    login = client.post("/portal/login", data={"email": "dev@example.com", "password": VALID_PW})
+    assert login.status_code == 200
+
+    dash = client.get("/portal/dashboard")
+    assert dash.status_code == 200
+    # Seção de BI e KPIs presentes no painel redesenhado.
+    assert "Chamadas de API no mês" in dash.text
+    assert "Taxa de sucesso" in dash.text
+    assert "Painel &amp; Analytics" in dash.text or "Painel & Analytics" in dash.text
+
+
+def test_change_password_flow(client, onboarded_account):
+    client.post("/portal/login", data={"email": "dev@example.com", "password": VALID_PW})
+
+    page = client.get("/portal/account/password")
+    assert page.status_code == 200
+    assert "Trocar senha" in page.text
+
+    # Senha atual errada → erro.
+    bad = client.post(
+        "/portal/account/password",
+        data={
+            "current_password": "errada-000000",
+            "new_password": "NovaSenha456",
+            "confirm_password": "NovaSenha456",
+        },
+    )
+    assert bad.status_code == 400
+
+    # Troca válida → confirmação.
+    ok = client.post(
+        "/portal/account/password",
+        data={
+            "current_password": VALID_PW,
+            "new_password": "NovaSenha456",
+            "confirm_password": "NovaSenha456",
+        },
+    )
+    assert ok.status_code == 200
+    assert "sucesso" in ok.text.lower()
+
+
+def test_change_password_confirmation_mismatch(client, onboarded_account):
+    client.post("/portal/login", data={"email": "dev@example.com", "password": VALID_PW})
+    r = client.post(
+        "/portal/account/password",
+        data={
+            "current_password": VALID_PW,
+            "new_password": "NovaSenha456",
+            "confirm_password": "OutraCoisa789",
+        },
+    )
+    assert r.status_code == 400
+    assert "confirmação" in r.text.lower()

--- a/tests/unit/test_charts.py
+++ b/tests/unit/test_charts.py
@@ -1,0 +1,72 @@
+"""
+Testes unitários do gerador de gráfico SSR (app/web/charts.py).
+
+Geometria determinística: escala "bonita" do eixo, mapeamento invertido (valor
+maior → mais alto na tela), rótulos de eixo e estados de borda (vazio/1 ponto).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from app.models.platform import UsageDailyPoint
+from app.web.charts import build_usage_chart
+
+
+def _series(values: list[tuple[int, int]], start: date | None = None) -> list[UsageDailyPoint]:
+    start = start or date(2026, 7, 1)
+    return [
+        UsageDailyPoint(date=start + timedelta(days=i), total=t, successful=s, failed=t - s)
+        for i, (t, s) in enumerate(values)
+    ]
+
+
+def test_empty_series_has_no_data():
+    chart = build_usage_chart([])
+    assert chart.has_data is False
+    assert chart.points == []
+    assert chart.total_line == ""
+
+
+def test_all_zero_series_is_flagged_empty_but_valid_axes():
+    chart = build_usage_chart(_series([(0, 0)] * 5))
+    assert chart.has_data is False
+    assert len(chart.points) == 5
+    assert chart.max_value >= 4  # eixo utilizável mesmo sem tráfego
+    assert chart.y_ticks  # rótulos do eixo Y existem
+
+
+def test_nice_max_covers_peak():
+    chart = build_usage_chart(_series([(0, 0), (772, 700), (1250, 1180)]))
+    assert chart.has_data is True
+    assert chart.max_value >= 1250
+    # Escala com 4 divisões → 5 rótulos (0 … max), topo "bonito" acima do pico.
+    assert len(chart.y_ticks) == 5
+    assert chart.y_ticks[0].label == "0"
+
+
+def test_higher_value_maps_higher_on_screen():
+    chart = build_usage_chart(_series([(100, 100), (1000, 900)]))
+    p_low, p_high = chart.points
+    # y cresce para baixo no SVG: total maior deve ter y MENOR (mais no topo).
+    assert p_high.y_total < p_low.y_total
+    # Bem-sucedidas <= total → linha de sucesso nunca acima da de total.
+    assert p_high.y_success >= p_high.y_total
+
+
+def test_paths_and_labels_shape():
+    series = _series([(10, 9), (20, 18), (30, 30)])
+    chart = build_usage_chart(series)
+    assert chart.total_area.startswith("M")
+    assert chart.total_area.endswith("Z")
+    assert len(chart.total_line.split(" ")) == 3
+    # O último dia sempre rotulado no eixo X.
+    assert chart.x_ticks[-1].label == "03/07"
+    assert chart.points[0].label == "01/07"
+
+
+def test_single_point_is_centered():
+    chart = build_usage_chart(_series([(50, 40)]))
+    assert len(chart.points) == 1
+    # Ponto único fica no centro horizontal da área de plotagem (entre as margens).
+    assert 400 < chart.points[0].x < 470


### PR DESCRIPTION
Refatora **acompanhamento de uso** e **gestão de senha**, e adiciona um **painel de BI** no portal (`/portal/dashboard`), conforme referência de dashboard analítico.

## O que muda

### BI de uso da IA (painel)
- Gráfico de área **SSR determinístico** (SVG server-side, sem JS/CDN de renderização; degrada para tabela acessível — Princípio VII): **total vs. bem-sucedidas por dia** (janela de 30 dias).
- KPIs: total de requisições + variação vs. período anterior, **taxa de sucesso**, uso de IA e keys ativas.
- Novo endpoint `GET /api/v1/usage/analytics` (`AccountAnalyticsResponse`).

### Rastreio de desfecho (taxa de sucesso real)
- Coluna aditiva `usage_records.error_count` (migração **0004**).
- `UsageOutcomeMiddleware` contabiliza chamadas com desfecho de erro (≥ 400) por key/bucket/dia, sem tocar o caminho quente das bem-sucedidas.

### Gestão de senha (API v1 + portal)
- **Trocar senha** autenticado — `POST /api/v1/auth/change-password` e `/portal/account/password`.
- **Esqueci/redefinir** por e-mail com token de uso único (tabela `password_reset_tokens`, migração **0005**); resposta **anti-enumeração** (Princípio V).

## Qualidade
- Suíte completa verde; **cobertura 87%** (gate ≥ 80%). ruff/black/mypy ok; migrações aplicam e revertem limpo.
- Snapshots de OpenAPI (contrato + release `v1/1.3.0`) recongelados para os caminhos **aditivos** sob `/api/v1` — sem quebra (Princípio I).

## Escopo do commit
Inclui apenas o que é responsabilidade desta feature. `styles.css` e `login.html` também carregam um refino visual em andamento no working tree (entrelaçado nos mesmos hunks, e o painel depende dos novos tokens de design). `landing.html` e `signup.html` — que são exclusivamente esse refino, sem dependência com esta feature — **foram deixados de fora** para commit separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)