### PR TITLE
feat(auditoria): fluxo externo, agêntico e incremental de fidelidade da BNCC

### DIFF
--- a/.claude/agents/bncc-auditor.md
+++ b/.claude/agents/bncc-auditor.md
@@ -1,0 +1,54 @@
+---
+name: bncc-auditor
+description: Assessor de auditoria de fidelidade da BNCC. Recebe UM relatório de lote gerado por scripts/audit_external.py e, para cada divergência (ou código "sem fontes"), pesquisa o texto oficial em fontes independentes e preenche no próprio relatório a análise, a proposta de correção (formato bncc_description_fixes.json) e a confiança. NUNCA altera data/ nem o snapshot — apenas o arquivo .md do relatório.
+tools: Read, Edit, Bash, Grep, Glob, WebSearch, WebFetch
+model: sonnet
+---
+
+Você é o **assessor de fidelidade da BNCC**. Seu produto é um relatório de auditoria
+enriquecido para **decisão humana** — você **propõe**, nunca aplica (Constituição,
+Princípios IV e VII).
+
+## Entrada
+O caminho de UM relatório em `audit/relatorios/AAAA-MM-DD-lote-NNNN.md`, já com a
+tabela por código e as seções "Divergências detalhadas" e "Propostas para
+bncc_description_fixes.json" com lacunas a preencher.
+
+## Regras invioláveis
+- **NÃO** edite `data/`, `data/bncc_v1.json`, `scripts/bncc_description_fixes.json`
+  nem qualquer código. Você edita **somente** o arquivo `.md` do relatório recebido.
+- Nenhuma fonte é verdade final. **Árbitro** de EI/EF = o PDF oficial
+  `data/BNCC_EI_EF_110518_versaofinal_site.pdf`. Para **Ensino Médio**, a seção do
+  PDF é rascunho mai/2018 — use CSV/snapshot homologado, nunca o PDF.
+- `WebSearch`/`WebFetch` são **sinal secundário** (fontes educacionais idôneas);
+  jamais árbitro. Sempre cite a fonte e a página/URL.
+- Se não conseguir adjudicar com segurança, diga isso e marque confiança **baixa**.
+
+## Procedimento (por código divergente ou "sem fontes")
+1. Leia no relatório o texto do snapshot e o(s) texto(s) das testemunhas.
+2. Confirme o texto oficial:
+   - Abra a região do árbitro. O mapa extraído está em
+     `audit/cache/arbiter_pdf.json` (código → trecho, com possível *bleed* de
+     coluna). Para ver o texto cru sem bleed, localize a página:
+     `venv/Scripts/python.exe -c "import pikepdf,io,pdfplumber,warnings; warnings.simplefilter('ignore'); p=pikepdf.open('data/BNCC_EI_EF_110518_versaofinal_site.pdf'); b=io.BytesIO(); p.save(b); p.close(); b.seek(0); d=pdfplumber.open(b); [print(i, (pg.extract_text() or '')[:0]) for i,pg in enumerate(d.pages)]"`
+     (ajuste para imprimir a página que contém o código).
+   - Cruze com a testemunha CSV se presente e, só então, com WebSearch/WebFetch.
+3. Decida: o **snapshot** está fiel? A divergência é (a) **defeito real do
+   snapshot** (bleed/truncamento/reordenação), (b) **ruído da testemunha**
+   (o snapshot está certo; a fonte é que traz bleed), ou (c) **inconclusivo**.
+4. Preencha **no relatório**, em cada divergência:
+   - `**Análise do assessor:**` — o veredito (a/b/c) com evidência e citação.
+   - `**Proposta de correção:**` — se (a): o texto oficial adjudicado + `fonte` +
+     `motivo` (`bleed`/`truncation`/`reorder`/…) + confiança (alta/média/baixa).
+       Se (b)/(c): registre "sem correção proposta" e por quê.
+5. No bloco final ```json```, deixe em `descricoes` **apenas** os códigos com
+   proposta (a), no formato exato de `scripts/bncc_description_fixes.json`
+   (`{ "CODIGO": {"descricao": "...", "fonte": "...", "motivo": "..."} }`).
+   Remova os demais placeholders.
+
+## Saída
+Edite o `.md` in place e devolva um resumo: nº analisado, nº com correção proposta
+(por confiança), nº classificado como ruído de testemunha, nº inconclusivo, e
+pendências (ex.: códigos "sem fontes" que precisam de uma testemunha nova).
+
+Nada em `data/` pode ter mudado — confirme isso no resumo.

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ ENV/
 .DS_Store
 Thumbs.db
 
+# Auditoria externa: cache de fontes (respostas de PDF/portal) nunca versionado.
+# Relatorios, ledger e PROGRESSO.md SAO versionados (produto da auditoria).
+/audit/cache/
+
 # Data Files
 # Ignora o CONTEUDO de data/ (nao o diretorio): so assim a negacao abaixo
 # consegue re-incluir o snapshot (o git nao re-inclui arquivo sob diretorio

--- a/audit/PROGRESSO.md
+++ b/audit/PROGRESSO.md
@@ -1,0 +1,13 @@
+# Progresso da auditoria externa de fidelidade
+
+**15/1717 habilidades auditadas (0.9%)** · ⚠️ 0 divergência(s) registrada(s).
+
+| Etapa | Auditadas | Total | % |
+|---|---:|---:|---:|
+| educacao_infantil | 0 | 104 | 0.0% |
+| ensino_fundamental | 15 | 1408 | 1.1% |
+| ensino_medio | 0 | 205 | 0.0% |
+
+## Relatórios por lote
+
+- [`2026-07-11-lote-0001.md`](relatorios/2026-07-11-lote-0001.md)

--- a/audit/ledger.json
+++ b/audit/ledger.json
@@ -1,0 +1,141 @@
+{
+  "gerado_em": "2026-07-11",
+  "snapshot_versao": "v1",
+  "codigos": {
+    "EF01CI01": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01CI02": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01CI03": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01CI04": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01CI05": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01CI06": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01CO01": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01CO02": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01CO03": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01CO04": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01CO05": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01CO06": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01CO07": {
+      "veredito": "sem_fontes",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": null
+    },
+    "EF01ER01": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    },
+    "EF01ER02": {
+      "veredito": "concordante",
+      "lote": 1,
+      "ultima_auditoria": "2026-07-11",
+      "fontes_consultadas": [
+        "arbiter_pdf"
+      ],
+      "melhor_cobertura": 1.0
+    }
+  }
+}

--- a/audit/relatorios/2026-07-11-lote-0001.md
+++ b/audit/relatorios/2026-07-11-lote-0001.md
@@ -1,0 +1,55 @@
+# Auditoria externa de fidelidade — lote 0001
+
+- **Data:** 2026-07-11
+- **Códigos:** 15 (EF01CI01 … EF01ER02)
+- **Fontes consultadas:** `arbiter_pdf`
+- **Limiar de concordância:** 0.92
+- **Snapshot:** versão `v1`
+- **checksum_fontes:** `{"ensino_fundamental": "81cd44ba5444ff1e8ff7b82d83512a49de9ce54efa72c4d285a452d3321128a4", "ensino_medio": "0428abc37903…`
+
+> ⚠️ Nenhuma fonte é tratada como verdade final. Este relatório apenas
+> **informa** a decisão humana. Correções aprovadas entram pelo fluxo
+> `scripts/reconcile_bncc_descriptions.py` (nunca automaticamente).
+
+## Resumo
+
+| Auditados | ✅ Concordantes | ⚠️ Divergentes | — Sem fontes |
+|---:|---:|---:|---:|
+| 15 | 8 | 0 | 7 |
+
+## Por código
+
+_Percentual = **cobertura**: quanto do texto do snapshot está sustentado pela fonte (extra na fonte não penaliza)._
+
+| Código | Etapa/Comp. | Status | `arbiter_pdf` |
+|---|---|---|---|
+| `EF01CI01` | ciencias | ✅ concordante | 100.0% |
+| `EF01CI02` | ciencias | ✅ concordante | 100.0% |
+| `EF01CI03` | ciencias | ✅ concordante | 100.0% |
+| `EF01CI04` | ciencias | ✅ concordante | 100.0% |
+| `EF01CI05` | ciencias | ✅ concordante | 100.0% |
+| `EF01CI06` | ciencias | ✅ concordante | 100.0% |
+| `EF01CO01` | computacao | — sem fontes | ausente |
+| `EF01CO02` | computacao | — sem fontes | ausente |
+| `EF01CO03` | computacao | — sem fontes | ausente |
+| `EF01CO04` | computacao | — sem fontes | ausente |
+| `EF01CO05` | computacao | — sem fontes | ausente |
+| `EF01CO06` | computacao | — sem fontes | ausente |
+| `EF01CO07` | computacao | — sem fontes | ausente |
+| `EF01ER01` | ensino_religioso | ✅ concordante | 100.0% |
+| `EF01ER02` | ensino_religioso | ✅ concordante | 100.0% |
+
+## Divergências detalhadas (0)
+
+_Nenhuma divergência acima do limiar neste lote._
+
+## Propostas para `scripts/bncc_description_fixes.json`
+
+Preencher apenas as aprovadas por revisão humana, então rodar
+`python scripts/reconcile_bncc_descriptions.py`.
+
+```json
+{
+  "descricoes": {}
+}
+```

--- a/docs/auditoria-externa.md
+++ b/docs/auditoria-externa.md
@@ -1,0 +1,131 @@
+# Auditoria externa e incremental de fidelidade da BNCC
+
+Fluxo **repetível, externo, agêntico e incremental** para auditar a fidelidade das
+descrições servidas pela API contra **fontes independentes** — cobrindo o corpus
+(~1.717 habilidades) **aos poucos**, ao longo do tempo. Governado pela Constituição
+(`.specify/memory/constitution.md`, Princípio IV — *Fidelidade dos dados* — e
+Princípio VII — *IA como camada não confiável, nunca dado oficial*).
+
+> **Este fluxo NÃO altera dados.** Ele produz **relatórios em Markdown** para
+> decisão humana. Uma correção só entra no snapshot depois de aprovada, pelo fluxo
+> existente `scripts/reconcile_bncc_descriptions.py` (chaveado por código,
+> idempotente). Nenhuma fonte é tratada como verdade final.
+
+## Onde isto se encaixa
+
+Já existiam três defesas de fidelidade, todas *internas* ou *de uma só vez*:
+
+| Ferramenta | O que faz | Limite |
+|---|---|---|
+| `scripts/audit_extraction.py` | qualidade do texto por assinaturas internas | auto-referencial (só olha o próprio snapshot) |
+| `scripts/validate_bncc_coverage.py` | códigos/contagens/integridade referencial | não olha o *conteúdo* das descrições |
+| `scripts/reconcile_bncc_descriptions.py` + `bncc_description_fixes.json` | correções adjudicadas contra 2 testemunhas | rodado **uma vez** (auditoria 2026-07-06), manual |
+
+Esta auditoria externa fecha a lacuna: cruza **cada** habilidade contra testemunhas
+**independentes**, de forma **repetível e incremental**, e entrega relatórios.
+
+## O fluxo de uma boa auditoria (as etapas)
+
+1. **Selecionar um lote** de habilidades ainda não auditadas (rastreado no ledger).
+2. **Coletar testemunhas** independentes de cada código (allowlist de fontes).
+3. **Comparar deterministicamente** o texto do snapshot com cada testemunha
+   (cobertura + similaridade). Classificar: concordante / divergente / sem fontes.
+4. **Assessoria agêntica** nas divergências: um agente pesquisa o texto oficial,
+   adjudica (defeito real do snapshot × ruído da testemunha × inconclusivo) e
+   **propõe** correção no relatório — com citação e confiança.
+5. **Revisão humana**: você decide. As correções aprovadas viram entradas em
+   `scripts/bncc_description_fixes.json` e entram pelo `reconcile`.
+6. **Registrar progresso** no ledger e no índice `PROGRESSO.md`; repetir com o
+   próximo lote (cobertura do corpus cresce ao longo do tempo).
+
+## Componentes
+
+```
+scripts/audit/engine.py           # comparação determinística (cobertura/similaridade)
+scripts/audit/sources/            # adaptadores de fonte (allowlist)
+  arbiter_pdf.py                  #   PDF oficial homologado (árbitro EI/EF)
+  bncc_mcp_csv.py                 #   CSV github.com/dfdb76/bncc-mcp (2ª testemunha)
+  mec_portal.py                   #   Portal BNCC/MEC (online + cache; a confirmar)
+scripts/audit_external.py         # CLI: lote → relatório + ledger + PROGRESSO
+audit/
+  ledger.json                     # estado por código (versionado)
+  PROGRESSO.md                    # índice legível (gerado)
+  relatorios/                     # relatórios .md por lote (versionados)
+  fontes/bncc_mcp/                # CSVs vendorizados (offline; ver bootstrap)
+  cache/                          # respostas de fontes (gitignored)
+.claude/agents/bncc-auditor.md    # o agente assessor
+```
+
+### Métrica de fidelidade: **cobertura**
+
+A classificação usa **cobertura** = fração do texto do snapshot que está sustentada
+pela testemunha (soma dos blocos casados ÷ tamanho do snapshot, via
+`difflib.SequenceMatcher`). Ela responde à pergunta certa — *"o texto oficial que
+servimos está presente na fonte?"* — e **tolera bleed de coluna** na extração da
+testemunha (texto EXTRA na fonte não penaliza). A `similaridade` (razão simétrica)
+é mostrada só como informação. Um código é **concordante** se a **melhor** fonte
+cobre ≥ `--limiar` (padrão `0.92`); **divergente** se nenhuma fonte cobre; **sem
+fontes** se nenhuma testemunha conhece o código.
+
+## Como rodar
+
+Use o Python do venv (traz `pdfplumber`/`pikepdf`/`httpx`):
+
+```bash
+# próximos 25 códigos não auditados (offline: só cache/arquivos locais)
+venv/Scripts/python.exe scripts/audit_external.py --lote 25 --offline
+
+# auditar códigos específicos
+venv/Scripts/python.exe scripts/audit_external.py --codigos EF01CI04,EF02LP28
+
+# revisitar já auditados (ex.: após vendorizar uma nova fonte)
+venv/Scripts/python.exe scripts/audit_external.py --lote 25 --reauditar
+```
+
+Saída: `audit/relatorios/AAAA-MM-DD-lote-NNNN.md` + `audit/ledger.json` +
+`audit/PROGRESSO.md` atualizados. Exit code é `0` mesmo com divergências (são
+achados, não erros). A **primeira** execução extrai o texto do árbitro (~1 min) e o
+cacheia em `audit/cache/arbiter_pdf.json`; as seguintes leem o cache.
+
+### Passo agêntico (assessor)
+
+Depois de gerar um lote, acione o agente sobre o relatório para enriquecer as
+divergências (ele só edita o `.md`, nunca `data/`):
+
+> Use o subagente `bncc-auditor` no relatório `audit/relatorios/2026-07-11-lote-0001.md`.
+
+Para cobrir o corpus **aos poucos**, encadeie via `/loop` (um lote por iteração):
+
+> `/loop venv/Scripts/python.exe scripts/audit_external.py --lote 25 --offline` e
+> depois acione `bncc-auditor` no relatório mais novo.
+
+## Bootstrap das fontes (uma vez)
+
+- **Árbitro (EI/EF)** — já disponível: `data/BNCC_EI_EF_110518_versaofinal_site.pdf`
+  (o adaptador normaliza com pikepdf e cacheia). Não cobre o **Complemento de
+  Computação** (`*CO*`) — esses códigos aparecem como *sem fontes* até haver uma
+  testemunha própria.
+- **CSV bncc-mcp (2ª testemunha, e referência de EM)** — baixe os CSVs de
+  `github.com/dfdb76/bncc-mcp` para `audit/fontes/bncc_mcp/`. O adaptador detecta as
+  colunas de código e descrição pelo cabeçalho automaticamente.
+- **Portal MEC** — dirigido por cache (`audit/cache/mec_portal/{codigo}.json`). O
+  gancho `MecPortalSource._coletar` está pronto para receber a coleta online quando
+  uma fonte por código for confirmada; enquanto isso, opera só sobre cache semeado.
+
+## Aplicando uma correção aprovada (decisão humana)
+
+1. No relatório, revise a **Proposta de correção** do agente e a citação.
+2. Copie a entrada aprovada para `scripts/bncc_description_fixes.json` (formato
+   `{ "CODIGO": {"descricao": "...", "fonte": "...", "motivo": "..."} }`).
+3. `venv/Scripts/python.exe scripts/reconcile_bncc_descriptions.py` (idempotente).
+4. Rode os portões: `pytest tests/contract/test_audit_extraction.py` e
+   `python scripts/validate_bncc_coverage.py`.
+
+## Princípios em jogo
+
+- **IV — Fidelidade**: a comparação é determinística, versionada e reproduzível
+  (cache offline); discrepâncias são tratadas como defeitos de correção.
+- **VII — IA não confiável**: o agente **propõe**; nada de IA vira dado oficial sem
+  adjudicação contra o árbitro e decisão humana.
+- **II — Camadas**: adaptadores isolam a infraestrutura (PDF/CSV/rede); o motor não
+  faz I/O de rede e é testável em isolamento.

--- a/scripts/audit/__init__.py
+++ b/scripts/audit/__init__.py
@@ -1,0 +1,6 @@
+"""Auditoria externa e incremental de fidelidade do snapshot da BNCC (Princípio IV).
+
+Este pacote NÃO altera dados: cruza cada habilidade do snapshot contra fontes
+independentes e produz relatórios em Markdown para decisão humana posterior. Ver
+`docs/auditoria-externa.md` e o CLI `scripts/audit_external.py`.
+"""

--- a/scripts/audit/engine.py
+++ b/scripts/audit/engine.py
@@ -1,0 +1,139 @@
+"""
+Motor determinístico de comparação da auditoria externa (Princípios IV e VII).
+
+Sem I/O de rede: recebe a habilidade do snapshot e as testemunhas já obtidas das
+fontes, normaliza (reuso de `_norm` de `reconcile_bncc_descriptions`) e mede, com
+`difflib.SequenceMatcher` (stdlib, determinístico, sem dependência nova), DUAS
+grandezas por fonte:
+
+  - `cobertura`   — fração do texto do snapshot que está presente na testemunha
+                    (soma dos blocos casados / tamanho do snapshot). É o SINAL DE
+                    FIDELIDADE: pergunta "o texto oficial que servimos está
+                    sustentado pela testemunha?". Tolera "bleed" de coluna na
+                    extração da testemunha (texto EXTRA na fonte não penaliza);
+  - `similaridade` — razão simétrica (informativa; cai quando a fonte tem bleed).
+
+Classifica cada código pela COBERTURA da melhor fonte:
+
+  - `concordante`      — há ≥1 fonte e a melhor cobertura fica ≥ limiar;
+  - `divergente`       — a melhor cobertura fica < limiar (candidato a revisão);
+  - `sem_fontes`       — nenhuma das fontes consultadas conhece o código.
+
+Divergências são ACHADOS para o relatório, não erros de execução. A decisão de
+corrigir o snapshot é sempre humana.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+
+from scripts.audit.sources import SourceRecord
+from scripts.reconcile_bncc_descriptions import _norm
+
+LIMIAR_PADRAO = 0.92
+
+STATUS_CONCORDANTE = "concordante"
+STATUS_DIVERGENTE = "divergente"
+STATUS_SEM_FONTES = "sem_fontes"
+
+
+@dataclass(frozen=True)
+class FonteComparacao:
+    """Resultado da comparação do snapshot contra UMA fonte, para um código."""
+
+    fonte: str
+    presente: bool
+    cobertura: float | None  # sinal de fidelidade; None se a fonte não conhece o código
+    similaridade: float | None  # razão simétrica (informativa)
+    descricao_fonte: str | None
+    url: str | None
+
+
+@dataclass
+class ResultadoCodigo:
+    """Veredito determinístico da auditoria de um código."""
+
+    codigo: str
+    etapa: str
+    componente: str | None
+    descricao_snapshot: str
+    status: str
+    limiar: float
+    fontes: list[FonteComparacao] = field(default_factory=list)
+
+    @property
+    def melhor_cobertura(self) -> float | None:
+        vals = [f.cobertura for f in self.fontes if f.cobertura is not None]
+        return max(vals) if vals else None
+
+    @property
+    def fontes_divergentes(self) -> list[FonteComparacao]:
+        return [
+            f
+            for f in self.fontes
+            if f.presente and f.cobertura is not None and f.cobertura < self.limiar
+        ]
+
+
+def similaridade(a: str, b: str) -> float:
+    """Razão de similaridade simétrica [0..1] entre dois textos, após normalização."""
+    return SequenceMatcher(None, _norm(a), _norm(b)).ratio()
+
+
+def cobertura(referencia: str, testemunha: str) -> float:
+    """Fração de `referencia` (snapshot) sustentada por `testemunha`, após normalizar.
+
+    Soma dos blocos casados dividida pelo tamanho da referência. Texto EXTRA na
+    testemunha (bleed de coluna na extração) não penaliza — mede-se só quanto do
+    texto oficial que servimos aparece na fonte.
+    """
+    ref = _norm(referencia)
+    if not ref:
+        return 0.0
+    sm = SequenceMatcher(None, ref, _norm(testemunha))
+    casado = sum(b.size for b in sm.get_matching_blocks())
+    return casado / len(ref)
+
+
+def comparar(
+    hab: dict,
+    registros: dict[str, SourceRecord | None],
+    *,
+    limiar: float = LIMIAR_PADRAO,
+) -> ResultadoCodigo:
+    """Compara uma habilidade do snapshot contra as testemunhas obtidas.
+
+    `registros` mapeia slug-da-fonte -> SourceRecord (ou None se a fonte foi
+    consultada mas não conhece o código). A ordem das fontes no resultado segue a
+    ordem de inserção de `registros`.
+    """
+    codigo = str(hab.get("codigo", "?"))
+    desc_snap = str(hab.get("descricao", ""))
+    fontes: list[FonteComparacao] = []
+
+    for slug, rec in registros.items():
+        if rec is None:
+            fontes.append(FonteComparacao(slug, False, None, None, None, None))
+            continue
+        cob = round(cobertura(desc_snap, rec.descricao), 4)
+        sim = round(similaridade(desc_snap, rec.descricao), 4)
+        fontes.append(FonteComparacao(slug, True, cob, sim, rec.descricao, rec.url))
+
+    presentes = [f for f in fontes if f.presente]
+    if not presentes:
+        status = STATUS_SEM_FONTES
+    elif all(f.cobertura is not None and f.cobertura < limiar for f in presentes):
+        status = STATUS_DIVERGENTE
+    else:
+        status = STATUS_CONCORDANTE
+
+    return ResultadoCodigo(
+        codigo=codigo,
+        etapa=str(hab.get("etapa", "?")),
+        componente=hab.get("componente"),
+        descricao_snapshot=desc_snap,
+        status=status,
+        limiar=limiar,
+        fontes=fontes,
+    )

--- a/scripts/audit/sources/__init__.py
+++ b/scripts/audit/sources/__init__.py
@@ -1,0 +1,102 @@
+"""
+Camada de fontes da auditoria externa de fidelidade da BNCC.
+
+Cada fonte é uma TESTEMUNHA INDEPENDENTE do texto oficial da BNCC. Nenhuma é
+tratada como verdade final — elas apenas informam os relatórios de auditoria; a
+decisão de corrigir o snapshot é sempre humana (Princípios IV e VII). Todo
+adaptador implementa a interface `Source`: declara `disponivel()` e resolve
+`fetch(codigo) -> SourceRecord | None`, degradando graciosamente quando a fonte,
+os arquivos ou a rede estão ausentes.
+
+Precedência de referência (ver CLAUDE.md): o PDF árbitro
+`BNCC_EI_EF_110518_versaofinal_site.pdf` é a testemunha primária em EI/EF; para o
+Ensino Médio a seção do PDF é rascunho de mai/2018, então lá a referência é o
+CSV/snapshot homologado, nunca o PDF.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger("audit_sources")
+
+# Slugs das fontes da allowlist, em ordem de precedência de referência.
+FONTES_PADRAO: tuple[str, ...] = ("arbiter_pdf", "bncc_mcp_csv", "mec_portal")
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    """Uma testemunha do texto de uma habilidade, vinda de uma fonte externa."""
+
+    fonte: str  # slug da fonte (ex.: "arbiter_pdf")
+    codigo: str
+    descricao: str
+    url: str  # proveniência: caminho do arquivo ou URL
+    obtido_em: str  # data ISO-8601 (AAAA-MM-DD)
+
+
+@runtime_checkable
+class Source(Protocol):
+    """Contrato de um adaptador de fonte independente."""
+
+    slug: str
+    nome: str
+
+    def disponivel(self) -> bool:
+        """True se a fonte pode responder consultas (arquivos/cache/rede prontos)."""
+        ...
+
+    def fetch(self, codigo: str) -> SourceRecord | None:
+        """Retorna a testemunha da fonte para `codigo`, ou None se ausente."""
+        ...
+
+
+def carregar_fontes(
+    slugs: tuple[str, ...] | list[str] | None = None,
+    *,
+    offline: bool = False,
+    cache_dir: Path | None = None,
+) -> list[Source]:
+    """Instancia os adaptadores pedidos, pulando (com aviso) os indisponíveis.
+
+    Import de cada adaptador é preguiçoso para que uma dependência ausente
+    (ex.: pdfplumber) desabilite só aquela fonte, sem derrubar as demais.
+    """
+    escolhidos = tuple(slugs) if slugs else FONTES_PADRAO
+    fontes: list[Source] = []
+    for slug in escolhidos:
+        try:
+            fonte = _instanciar(slug, offline=offline, cache_dir=cache_dir)
+        except ImportError as exc:
+            logger.warning("Fonte %s indisponível (dependência ausente): %s", slug, exc)
+            continue
+        except Exception as exc:  # noqa: BLE001 — degradação graciosa por fonte
+            logger.warning("Fonte %s falhou ao inicializar: %s", slug, exc)
+            continue
+        if fonte is None:
+            logger.warning("Fonte desconhecida ignorada: %s", slug)
+            continue
+        if not fonte.disponivel():
+            logger.info("Fonte %s indisponível nesta execução (sem arquivos/cache).", slug)
+            continue
+        fontes.append(fonte)
+    return fontes
+
+
+def _instanciar(slug: str, *, offline: bool, cache_dir: Path | None) -> Source | None:
+    if slug == "arbiter_pdf":
+        from scripts.audit.sources.arbiter_pdf import ArbiterPdfSource
+
+        return ArbiterPdfSource(cache_dir=cache_dir)
+    if slug == "bncc_mcp_csv":
+        from scripts.audit.sources.bncc_mcp_csv import BnccMcpCsvSource
+
+        return BnccMcpCsvSource()
+    if slug == "mec_portal":
+        from scripts.audit.sources.mec_portal import MecPortalSource
+
+        return MecPortalSource(offline=offline, cache_dir=cache_dir)
+    return None

--- a/scripts/audit/sources/arbiter_pdf.py
+++ b/scripts/audit/sources/arbiter_pdf.py
@@ -1,0 +1,127 @@
+"""
+Adaptador da testemunha ÁRBITRO: o documento oficial homologado
+`data/BNCC_EI_EF_110518_versaofinal_site.pdf` (EI+EF+EM, 600 págs.).
+
+É a testemunha primária em Educação Infantil e Ensino Fundamental. Para o Ensino
+Médio a seção deste PDF é o rascunho de mai/2018 (pré-homologação) — por isso
+`fetch()` NÃO retorna códigos de EM (a referência de EM é o CSV/snapshot
+homologado; ver CLAUDE.md e `bncc_mcp_csv`).
+
+Extração: como o page tree do PDF impede o pdfplumber direto, normaliza-se com
+pikepdf em memória; o texto de todas as páginas é concatenado em ordem de leitura
+e fatiado pelos marcadores de código `(EFxxYY##)`/`(EIxxYY##)` — a descrição de um
+código é o texto entre o seu marcador e o próximo. É melhor-esforço: a diagramação
+multicoluna pode trazer "bleed" de coluna vizinha, então a testemunha serve para
+SINALIZAR divergências para revisão humana, não como recorte perfeito. O mapa
+código→texto é cacheado em `audit/cache/arbiter_pdf.json` (extração única; reruns
+e execuções offline leem o cache).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import warnings
+from datetime import date
+from pathlib import Path
+
+from scripts.audit.sources import SourceRecord
+
+logger = logging.getLogger("audit_sources.arbiter_pdf")
+
+_ROOT = Path(__file__).resolve().parents[3]
+_PDF_PADRAO = _ROOT / "data" / "BNCC_EI_EF_110518_versaofinal_site.pdf"
+_CACHE_PADRAO = _ROOT / "audit" / "cache"
+
+# Marcador de código entre parênteses (EI/EF); EM é deliberadamente ignorado.
+_MARCADOR = re.compile(r"\((E[IF]\d{2}[A-Z]{2,3}\d{2,3})\)")
+_MAX_CAPTURA = 600  # descrições oficiais raramente passam disso; corta bleed grande.
+
+
+class ArbiterPdfSource:
+    slug = "arbiter_pdf"
+    nome = "PDF oficial homologado (árbitro EI/EF)"
+
+    def __init__(self, pdf: Path | None = None, cache_dir: Path | None = None):
+        self._pdf = pdf or _PDF_PADRAO
+        self._cache = (cache_dir or _CACHE_PADRAO) / "arbiter_pdf.json"
+        self._mapa: dict[str, str] | None = None
+
+    def disponivel(self) -> bool:
+        return self._cache.exists() or self._pdf.exists()
+
+    def fetch(self, codigo: str) -> SourceRecord | None:
+        if codigo.startswith("EM"):
+            return None  # seção de EM do PDF é rascunho — não é testemunha válida
+        mapa = self._carregar()
+        desc = mapa.get(codigo)
+        if not desc:
+            return None
+        return SourceRecord(
+            fonte=self.slug,
+            codigo=codigo,
+            descricao=desc,
+            url=f"{self._pdf.name}#(codigo)",
+            obtido_em=date.today().isoformat(),
+        )
+
+    # -- interno -----------------------------------------------------------
+
+    def _carregar(self) -> dict[str, str]:
+        if self._mapa is not None:
+            return self._mapa
+        if self._cache.exists():
+            dados = json.loads(self._cache.read_text(encoding="utf-8"))
+            self._mapa = dict(dados.get("descricoes", {}))
+            return self._mapa
+        self._mapa = self._extrair()
+        self._cache.parent.mkdir(parents=True, exist_ok=True)
+        self._cache.write_text(
+            json.dumps(
+                {
+                    "gerado_em": date.today().isoformat(),
+                    "fonte_pdf": self._pdf.name,
+                    "descricoes": self._mapa,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        logger.info("Cache do árbitro gravado: %s (%d códigos)", self._cache, len(self._mapa))
+        return self._mapa
+
+    def _extrair(self) -> dict[str, str]:
+        import io
+
+        import pdfplumber
+        import pikepdf
+
+        logger.info("Extraindo texto do árbitro %s (pode levar ~1 min)...", self._pdf.name)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            pdf = pikepdf.open(self._pdf)
+            buf = io.BytesIO()
+            pdf.save(buf)
+            pdf.close()
+            buf.seek(0)
+            partes: list[str] = []
+            with pdfplumber.open(buf) as doc:
+                for pg in doc.pages:
+                    partes.append(pg.extract_text() or "")
+        texto = "\n".join(partes)
+
+        mapa: dict[str, str] = {}
+        marcas = list(_MARCADOR.finditer(texto))
+        for i, m in enumerate(marcas):
+            codigo = m.group(1)
+            fim = marcas[i + 1].start() if i + 1 < len(marcas) else len(texto)
+            trecho = re.sub(r"\s+", " ", texto[m.end() : fim]).strip()
+            if len(trecho) > _MAX_CAPTURA:
+                trecho = trecho[:_MAX_CAPTURA].rsplit(" ", 1)[0]
+            # Guarda o trecho mais longo por código (evita capturas de citação curta).
+            if trecho and len(trecho) > len(mapa.get(codigo, "")):
+                mapa[codigo] = trecho
+        return mapa

--- a/scripts/audit/sources/bncc_mcp_csv.py
+++ b/scripts/audit/sources/bncc_mcp_csv.py
@@ -1,0 +1,97 @@
+"""
+Adaptador da testemunha CSV `github.com/dfdb76/bncc-mcp` (versão final homologada).
+
+Os CSVs casam 100% com o PDF árbitro nos códigos de EI+EF e foram usados na
+reconciliação de 2026-07-06. Aqui servem como SEGUNDA testemunha independente e,
+para o Ensino Médio, como referência preferencial (a seção de EM do PDF é rascunho).
+
+Bootstrap (passo único, offline depois): baixe os CSVs do repositório para
+`audit/fontes/bncc_mcp/` — ver `docs/auditoria-externa.md`. O adaptador é flexível
+quanto ao layout: varre todos os `.csv` da pasta e detecta as colunas de código e
+descrição pelo cabeçalho. Sem a pasta/arquivos, degrada graciosamente (indisponível).
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from datetime import date
+from pathlib import Path
+
+from scripts.audit.sources import SourceRecord
+
+logger = logging.getLogger("audit_sources.bncc_mcp_csv")
+
+_ROOT = Path(__file__).resolve().parents[3]
+_DIR_PADRAO = _ROOT / "audit" / "fontes" / "bncc_mcp"
+
+_CODIGO = re.compile(r"^E[IFM]\d{2}[A-Z]{2,3}\d{2,3}$")
+_HDR_CODIGO = ("codigo", "código", "code", "cod")
+_HDR_DESC = ("descricao", "descrição", "habilidade", "description", "texto")
+
+
+def _col(headers: list[str], candidatos: tuple[str, ...]) -> str | None:
+    for h in headers:
+        hl = h.strip().lower()
+        if any(c in hl for c in candidatos):
+            return h
+    return None
+
+
+class BnccMcpCsvSource:
+    slug = "bncc_mcp_csv"
+    nome = "CSV bncc-mcp (versão final homologada)"
+
+    def __init__(self, diretorio: Path | None = None):
+        self._dir = diretorio or _DIR_PADRAO
+        self._mapa: dict[str, str] | None = None
+
+    def disponivel(self) -> bool:
+        return self._dir.is_dir() and any(self._dir.glob("*.csv"))
+
+    def fetch(self, codigo: str) -> SourceRecord | None:
+        desc = self._carregar().get(codigo)
+        if not desc:
+            return None
+        return SourceRecord(
+            fonte=self.slug,
+            codigo=codigo,
+            descricao=desc,
+            url="github.com/dfdb76/bncc-mcp",
+            obtido_em=date.today().isoformat(),
+        )
+
+    def _carregar(self) -> dict[str, str]:
+        if self._mapa is not None:
+            return self._mapa
+        mapa: dict[str, str] = {}
+        for arq in sorted(self._dir.glob("*.csv")):
+            try:
+                self._ler_csv(arq, mapa)
+            except Exception as exc:  # noqa: BLE001 — degradação por arquivo
+                logger.warning("Falha lendo %s: %s", arq.name, exc)
+        self._mapa = mapa
+        return mapa
+
+    @staticmethod
+    def _ler_csv(arq: Path, mapa: dict[str, str]) -> None:
+        with arq.open(encoding="utf-8-sig", newline="") as fh:
+            amostra = fh.read(2048)
+            fh.seek(0)
+            try:
+                dialeto = csv.Sniffer().sniff(amostra, delimiters=",;\t")
+            except csv.Error:
+                dialeto = csv.excel
+            leitor = csv.DictReader(fh, dialect=dialeto)
+            if not leitor.fieldnames:
+                return
+            col_cod = _col(list(leitor.fieldnames), _HDR_CODIGO)
+            col_desc = _col(list(leitor.fieldnames), _HDR_DESC)
+            if not col_cod or not col_desc:
+                return
+            for linha in leitor:
+                cod = (linha.get(col_cod) or "").strip()
+                desc = (linha.get(col_desc) or "").strip()
+                if _CODIGO.match(cod) and desc and cod not in mapa:
+                    mapa[cod] = desc

--- a/scripts/audit/sources/mec_portal.py
+++ b/scripts/audit/sources/mec_portal.py
@@ -1,0 +1,104 @@
+"""
+Adaptador da testemunha PORTAL MEC (`basenacionalcomum.mec.gov.br`).
+
+Testemunha online, consultada por código e CACHEADA em
+`audit/cache/mec_portal/{codigo}.json` — a rede é usada só na primeira vez; reruns
+e execuções `--offline` leem exclusivamente o cache (reprodutibilidade e CI sem
+rede). Sem cache e sem rede, degrada graciosamente (retorna None).
+
+NOTA: o portal do MEC é uma aplicação JS e não expõe um endpoint por código
+estável e verificado. Por isso este adaptador é dirigido pelo CACHE: a coleta
+online fica atrás de `MecPortalSource._buscar_online`, um gancho a ser confirmado/
+ajustado conforme a fonte disponível (ver `docs/auditoria-externa.md`). Enquanto
+não confirmado, o adaptador opera apenas sobre entradas de cache já semeadas.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date
+from pathlib import Path
+
+from scripts.audit.sources import SourceRecord
+
+logger = logging.getLogger("audit_sources.mec_portal")
+
+_ROOT = Path(__file__).resolve().parents[3]
+_CACHE_PADRAO = _ROOT / "audit" / "cache"
+
+
+class MecPortalSource:
+    slug = "mec_portal"
+    nome = "Portal BNCC/MEC (basenacionalcomum.mec.gov.br)"
+
+    def __init__(self, offline: bool = False, cache_dir: Path | None = None):
+        self._offline = offline
+        self._cache_dir = (cache_dir or _CACHE_PADRAO) / "mec_portal"
+
+    def disponivel(self) -> bool:
+        # Disponível se há qualquer cache semeado, ou se podemos ir à rede.
+        if self._cache_dir.is_dir() and any(self._cache_dir.glob("*.json")):
+            return True
+        return not self._offline
+
+    def fetch(self, codigo: str) -> SourceRecord | None:
+        cache = self._cache_dir / f"{codigo}.json"
+        if cache.exists():
+            dados = json.loads(cache.read_text(encoding="utf-8"))
+            desc = (dados.get("descricao") or "").strip()
+            if not desc:
+                return None
+            return SourceRecord(
+                fonte=self.slug,
+                codigo=codigo,
+                descricao=desc,
+                url=dados.get("url", ""),
+                obtido_em=dados.get("obtido_em", ""),
+            )
+        if self._offline:
+            return None
+        return self._buscar_online(codigo)
+
+    # -- interno -----------------------------------------------------------
+
+    def _buscar_online(self, codigo: str) -> SourceRecord | None:
+        """Gancho de coleta online (a confirmar). Grava no cache quando bem-sucedido.
+
+        Mantido conservador: qualquer falha degrada para None sem propagar exceção,
+        para que a auditoria continue com as demais fontes (Princípio VII).
+        """
+        try:
+            registro = self._coletar(codigo)
+        except Exception as exc:  # noqa: BLE001 — nunca derrubar a auditoria pela rede
+            logger.info("MEC portal indisponível para %s: %s", codigo, exc)
+            return None
+        if registro is None:
+            return None
+        self._gravar_cache(registro)
+        return registro
+
+    def _coletar(self, codigo: str) -> SourceRecord | None:
+        """Coleta real do portal. Sem endpoint por código confirmado, retorna None.
+
+        Para habilitar: implementar a chamada (httpx) contra a fonte confirmada e
+        montar o SourceRecord. Ver docs/auditoria-externa.md.
+        """
+        return None
+
+    def _gravar_cache(self, rec: SourceRecord) -> None:
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        (self._cache_dir / f"{rec.codigo}.json").write_text(
+            json.dumps(
+                {
+                    "codigo": rec.codigo,
+                    "descricao": rec.descricao,
+                    "url": rec.url,
+                    "obtido_em": rec.obtido_em or date.today().isoformat(),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )

--- a/scripts/audit_external.py
+++ b/scripts/audit_external.py
@@ -1,0 +1,380 @@
+"""
+Auditoria externa e incremental de fidelidade da BNCC — gerador de relatórios.
+
+NÃO altera dados (Princípios IV/VII): seleciona um lote de habilidades do snapshot,
+cruza cada uma contra fontes independentes (ver `scripts/audit/sources/`) por
+similaridade determinística e emite um RELATÓRIO em Markdown para decisão humana.
+Mantém um ledger (`audit/ledger.json`) do que já foi auditado — permitindo cobrir
+o corpus (~1.717 habilidades) aos poucos — e regenera um índice `audit/PROGRESSO.md`.
+
+Uso:
+    python scripts/audit_external.py --lote 25            # próximos 25 não auditados
+    python scripts/audit_external.py --codigos EF01CI01,EF01CI02
+    python scripts/audit_external.py --lote 25 --reauditar  # revisita já auditados
+    python scripts/audit_external.py --lote 25 --offline    # só cache/arquivos locais
+
+As divergências são ACHADOS para o relatório (não erros): exit code 0 mesmo com
+divergências; != 0 apenas em erro de execução (snapshot ausente etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("audit_external")
+
+ROOT = Path(__file__).resolve().parent.parent
+import sys  # noqa: E402
+
+sys.path.insert(0, str(ROOT))
+
+from scripts.audit.engine import (  # noqa: E402
+    LIMIAR_PADRAO,
+    STATUS_CONCORDANTE,
+    STATUS_DIVERGENTE,
+    STATUS_SEM_FONTES,
+    ResultadoCodigo,
+    comparar,
+)
+from scripts.audit.sources import Source, carregar_fontes  # noqa: E402
+
+DEFAULT_SNAPSHOT = ROOT / "data" / "bncc_v1.json"
+AUDIT_DIR = ROOT / "audit"
+LEDGER_PATH = AUDIT_DIR / "ledger.json"
+RELATORIOS_DIR = AUDIT_DIR / "relatorios"
+PROGRESSO_PATH = AUDIT_DIR / "PROGRESSO.md"
+
+_STATUS_ICON = {
+    STATUS_CONCORDANTE: "✅ concordante",
+    STATUS_DIVERGENTE: "⚠️ divergente",
+    STATUS_SEM_FONTES: "— sem fontes",
+}
+
+
+# --------------------------------------------------------------------------
+# Ledger (estado incremental por código)
+# --------------------------------------------------------------------------
+def carregar_ledger(path: Path = LEDGER_PATH) -> dict[str, Any]:
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {"gerado_em": "", "snapshot_versao": "", "codigos": {}}
+
+
+def proximo_lote(ledger: dict[str, Any]) -> int:
+    lotes = [e.get("lote", 0) for e in ledger.get("codigos", {}).values()]
+    return (max(lotes) + 1) if lotes else 1
+
+
+def atualizar_ledger(
+    ledger: dict[str, Any],
+    resultados: list[ResultadoCodigo],
+    lote: int,
+    hoje: str,
+    snapshot_versao: str,
+) -> dict[str, Any]:
+    """Aplica os vereditos ao ledger. Idempotente: mesmos argumentos → mesmo estado."""
+    ledger["gerado_em"] = hoje
+    ledger["snapshot_versao"] = snapshot_versao
+    cods = ledger.setdefault("codigos", {})
+    for r in resultados:
+        cods[r.codigo] = {
+            "veredito": r.status,
+            "lote": lote,
+            "ultima_auditoria": hoje,
+            "fontes_consultadas": [f.fonte for f in r.fontes],
+            "melhor_cobertura": r.melhor_cobertura,
+        }
+    return ledger
+
+
+# --------------------------------------------------------------------------
+# Seleção de lote
+# --------------------------------------------------------------------------
+def selecionar(
+    habs: list[dict[str, Any]],
+    ledger: dict[str, Any],
+    *,
+    n: int | None,
+    codigos: list[str] | None,
+    reauditar: bool,
+) -> list[dict[str, Any]]:
+    por_codigo = {h["codigo"]: h for h in habs}
+    if codigos:
+        return [por_codigo[c] for c in codigos if c in por_codigo]
+    auditados = set(ledger.get("codigos", {}))
+    candidatos = sorted(habs, key=lambda h: h["codigo"])
+    if not reauditar:
+        candidatos = [h for h in candidatos if h["codigo"] not in auditados]
+    return candidatos[: (n or 0)]
+
+
+# --------------------------------------------------------------------------
+# Execução da auditoria de um lote
+# --------------------------------------------------------------------------
+def auditar(
+    selecao: list[dict[str, Any]],
+    fontes: list[Source],
+    *,
+    limiar: float,
+) -> list[ResultadoCodigo]:
+    resultados: list[ResultadoCodigo] = []
+    for hab in selecao:
+        registros = {f.slug: f.fetch(hab["codigo"]) for f in fontes}
+        resultados.append(comparar(hab, registros, limiar=limiar))
+    return resultados
+
+
+# --------------------------------------------------------------------------
+# Renderização do relatório Markdown
+# --------------------------------------------------------------------------
+def _pct(sim: float | None) -> str:
+    return f"{sim * 100:.1f}%" if sim is not None else "—"
+
+
+def render_relatorio(
+    resultados: list[ResultadoCodigo],
+    *,
+    lote: int,
+    hoje: str,
+    fontes: list[Source],
+    limiar: float,
+    snapshot_meta: dict[str, Any],
+) -> str:
+    slugs = [f.slug for f in fontes]
+    n = len(resultados)
+    n_conc = sum(1 for r in resultados if r.status == STATUS_CONCORDANTE)
+    n_div = sum(1 for r in resultados if r.status == STATUS_DIVERGENTE)
+    n_sem = sum(1 for r in resultados if r.status == STATUS_SEM_FONTES)
+    faixa = f"{resultados[0].codigo} … {resultados[-1].codigo}" if resultados else "—"
+
+    L: list[str] = []
+    L.append(f"# Auditoria externa de fidelidade — lote {lote:04d}")
+    L.append("")
+    L.append(f"- **Data:** {hoje}")
+    L.append(f"- **Códigos:** {n} ({faixa})")
+    L.append(f"- **Fontes consultadas:** {', '.join(f'`{s}`' for s in slugs) or '_nenhuma_'}")
+    L.append(f"- **Limiar de concordância:** {limiar:.2f}")
+    L.append(f"- **Snapshot:** versão `{snapshot_meta.get('versao', '?')}`")
+    checks = snapshot_meta.get("checksum_fontes", {})
+    if checks:
+        L.append(f"- **checksum_fontes:** `{json.dumps(checks, ensure_ascii=False)[:120]}…`")
+    L.append("")
+    L.append("> ⚠️ Nenhuma fonte é tratada como verdade final. Este relatório apenas")
+    L.append("> **informa** a decisão humana. Correções aprovadas entram pelo fluxo")
+    L.append("> `scripts/reconcile_bncc_descriptions.py` (nunca automaticamente).")
+    L.append("")
+    L.append("## Resumo")
+    L.append("")
+    L.append("| Auditados | ✅ Concordantes | ⚠️ Divergentes | — Sem fontes |")
+    L.append("|---:|---:|---:|---:|")
+    L.append(f"| {n} | {n_conc} | {n_div} | {n_sem} |")
+    L.append("")
+
+    # Tabela por código
+    L.append("## Por código")
+    L.append("")
+    L.append(
+        "_Percentual = **cobertura**: quanto do texto do snapshot está sustentado "
+        "pela fonte (extra na fonte não penaliza)._"
+    )
+    L.append("")
+    cab = ["Código", "Etapa/Comp.", "Status"] + [f"`{s}`" for s in slugs]
+    L.append("| " + " | ".join(cab) + " |")
+    L.append("|" + "|".join(["---"] * len(cab)) + "|")
+    for r in resultados:
+        comp = r.componente or (r.etapa.split("_")[-1] if r.etapa else "—")
+        sims = {f.fonte: f for f in r.fontes}
+        cells = [f"`{r.codigo}`", comp, _STATUS_ICON.get(r.status, r.status)]
+        for s in slugs:
+            f = sims.get(s)
+            cells.append(_pct(f.cobertura) if f and f.presente else "ausente")
+        L.append("| " + " | ".join(cells) + " |")
+    L.append("")
+
+    # Divergências detalhadas
+    divergentes = [r for r in resultados if r.status == STATUS_DIVERGENTE]
+    L.append(f"## Divergências detalhadas ({len(divergentes)})")
+    L.append("")
+    if not divergentes:
+        L.append("_Nenhuma divergência acima do limiar neste lote._")
+        L.append("")
+    for r in divergentes:
+        L.append(f"### `{r.codigo}` — {r.etapa}")
+        L.append("")
+        L.append("**Snapshot atual:**")
+        L.append("")
+        L.append(f"> {r.descricao_snapshot}")
+        L.append("")
+        for f in r.fontes:
+            if not f.presente:
+                L.append(f"- `{f.fonte}`: _código ausente nesta fonte._")
+                continue
+            L.append(
+                f"**`{f.fonte}`** (cobertura {_pct(f.cobertura)}, "
+                f"similaridade {_pct(f.similaridade)}) — {f.url}:"
+            )
+            L.append("")
+            L.append(f"> {f.descricao_fonte}")
+            L.append("")
+        L.append(
+            "**Análise do assessor:** _(a preencher pelo agente — ver `docs/auditoria-externa.md`)_"
+        )
+        L.append("")
+        L.append(
+            "**Proposta de correção:** _(a preencher; citar a fonte/página árbitro e a confiança)_"
+        )
+        L.append("")
+
+    # Rodapé: bloco copiável para bncc_description_fixes.json
+    L.append("## Propostas para `scripts/bncc_description_fixes.json`")
+    L.append("")
+    L.append("Preencher apenas as aprovadas por revisão humana, então rodar")
+    L.append("`python scripts/reconcile_bncc_descriptions.py`.")
+    L.append("")
+    L.append("```json")
+    exemplo = {
+        r.codigo: {
+            "descricao": "<texto oficial adjudicado>",
+            "fonte": "arbiter_pdf",
+            "motivo": "<...>",
+        }
+        for r in divergentes
+    }
+    L.append(json.dumps({"descricoes": exemplo}, ensure_ascii=False, indent=2))
+    L.append("```")
+    L.append("")
+    return "\n".join(L)
+
+
+# --------------------------------------------------------------------------
+# Índice de progresso
+# --------------------------------------------------------------------------
+def render_progresso(
+    ledger: dict[str, Any],
+    habs: list[dict[str, Any]],
+    relatorios_dir: Path,
+) -> str:
+    total = len(habs)
+    cods = ledger.get("codigos", {})
+    auditados = len(cods)
+    por_etapa_total: dict[str, int] = {}
+    por_etapa_aud: dict[str, int] = {}
+    for h in habs:
+        et = h.get("etapa", "?")
+        por_etapa_total[et] = por_etapa_total.get(et, 0) + 1
+        if h["codigo"] in cods:
+            por_etapa_aud[et] = por_etapa_aud.get(et, 0) + 1
+    n_div = sum(1 for e in cods.values() if e.get("veredito") == STATUS_DIVERGENTE)
+
+    L: list[str] = []
+    L.append("# Progresso da auditoria externa de fidelidade")
+    L.append("")
+    pct = (auditados / total * 100) if total else 0.0
+    L.append(
+        f"**{auditados}/{total} habilidades auditadas ({pct:.1f}%)** · "
+        f"⚠️ {n_div} divergência(s) registrada(s)."
+    )
+    L.append("")
+    L.append("| Etapa | Auditadas | Total | % |")
+    L.append("|---|---:|---:|---:|")
+    for et in sorted(por_etapa_total):
+        a = por_etapa_aud.get(et, 0)
+        t = por_etapa_total[et]
+        L.append(f"| {et} | {a} | {t} | {(a / t * 100) if t else 0:.1f}% |")
+    L.append("")
+    L.append("## Relatórios por lote")
+    L.append("")
+    relatorios = sorted(relatorios_dir.glob("*-lote-*.md")) if relatorios_dir.exists() else []
+    if not relatorios:
+        L.append("_Nenhum relatório gerado ainda._")
+    for rel in relatorios:
+        L.append(f"- [`{rel.name}`](relatorios/{rel.name})")
+    L.append("")
+    return "\n".join(L)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Auditoria externa de fidelidade da BNCC (relatórios)."
+    )
+    ap.add_argument(
+        "--lote", type=int, default=None, help="Nº de habilidades a auditar neste lote."
+    )
+    ap.add_argument(
+        "--codigos", type=str, default=None, help="Lista de códigos (vírgula) a auditar."
+    )
+    ap.add_argument("--reauditar", action="store_true", help="Revisita códigos já auditados.")
+    ap.add_argument("--offline", action="store_true", help="Só cache/arquivos locais (sem rede).")
+    ap.add_argument("--limiar", type=float, default=LIMIAR_PADRAO, help="Limiar de concordância.")
+    ap.add_argument("--snapshot", type=str, default=None, help="Caminho do snapshot.")
+    args = ap.parse_args()
+
+    snap_path = Path(args.snapshot) if args.snapshot else DEFAULT_SNAPSHOT
+    if not snap_path.exists():
+        logger.error("Snapshot não encontrado: %s", snap_path)
+        return 2
+    snap = json.loads(snap_path.read_text(encoding="utf-8"))
+    habs = snap["habilidades"]
+    snap_meta = snap.get("metadata", {})
+
+    codigos = [c.strip() for c in args.codigos.split(",")] if args.codigos else None
+    if not codigos and not args.lote:
+        logger.error("Informe --lote N ou --codigos A,B,...")
+        return 2
+
+    ledger = carregar_ledger()
+    selecao = selecionar(habs, ledger, n=args.lote, codigos=codigos, reauditar=args.reauditar)
+    if not selecao:
+        logger.info("Nada a auditar (corpus coberto ou seleção vazia).")
+        return 0
+
+    fontes = carregar_fontes(offline=args.offline)
+    if not fontes:
+        logger.warning("Nenhuma fonte disponível — o relatório sairá sem testemunhas.")
+
+    resultados = auditar(selecao, fontes, limiar=args.limiar)
+    hoje = date.today().isoformat()
+    lote = proximo_lote(ledger)
+
+    RELATORIOS_DIR.mkdir(parents=True, exist_ok=True)
+    rel_path = RELATORIOS_DIR / f"{hoje}-lote-{lote:04d}.md"
+    rel_path.write_text(
+        render_relatorio(
+            resultados,
+            lote=lote,
+            hoje=hoje,
+            fontes=fontes,
+            limiar=args.limiar,
+            snapshot_meta=snap_meta,
+        ),
+        encoding="utf-8",
+    )
+
+    atualizar_ledger(ledger, resultados, lote, hoje, snap_meta.get("versao", ""))
+    LEDGER_PATH.write_text(
+        json.dumps(ledger, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    PROGRESSO_PATH.write_text(render_progresso(ledger, habs, RELATORIOS_DIR), encoding="utf-8")
+
+    n_div = sum(1 for r in resultados if r.status == STATUS_DIVERGENTE)
+    logger.info(
+        "Lote %04d: %d auditados, %d divergência(s). Relatório: %s",
+        lote,
+        len(resultados),
+        n_div,
+        rel_path,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contract/test_audit_external.py
+++ b/tests/contract/test_audit_external.py
@@ -1,0 +1,133 @@
+"""
+Testes da FERRAMENTA de auditoria externa de fidelidade (Princípio III).
+
+Verifica o comportamento do motor determinístico e do ledger — NÃO transforma a
+auditoria em portão de dados: divergências são achados esperados para o relatório,
+não falhas. Cobre:
+
+  - classificação por cobertura (concordante / divergente / sem_fontes);
+  - tolerância a "bleed" da testemunha (cobertura ignora texto extra na fonte);
+  - o caminho `--offline` não faz rede;
+  - o ledger é idempotente (aplicar 2× os mesmos vereditos → estado idêntico).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.audit.engine import (  # noqa: E402
+    STATUS_CONCORDANTE,
+    STATUS_DIVERGENTE,
+    STATUS_SEM_FONTES,
+    cobertura,
+    comparar,
+)
+from scripts.audit.sources import SourceRecord, carregar_fontes  # noqa: E402
+from scripts.audit_external import atualizar_ledger, proximo_lote, selecionar  # noqa: E402
+
+_OFICIAL = (
+    "Comparar características de diferentes materiais presentes em objetos de uso "
+    "cotidiano, discutindo sua origem, os modos como são descartados e como podem "
+    "ser usados de forma mais consciente."
+)
+
+
+def _rec(fonte: str, desc: str, codigo: str = "EF01CI01") -> SourceRecord:
+    return SourceRecord(fonte=fonte, codigo=codigo, descricao=desc, url="x", obtido_em="2026-07-11")
+
+
+# -- motor: cobertura -------------------------------------------------------
+def test_cobertura_ignora_bleed_da_testemunha():
+    """Texto oficial + bleed de coluna na fonte ⇒ cobertura permanece total."""
+    testemunha = _OFICIAL + " Vida e evolução Corpo humano"  # bleed de coluna
+    assert cobertura(_OFICIAL, testemunha) == 1.0
+
+
+def test_cobertura_penaliza_texto_do_snapshot_ausente_na_fonte():
+    """Se o snapshot tem conteúdo que a fonte não sustenta, a cobertura cai."""
+    fonte_incompleta = "Comparar características de diferentes materiais."
+    assert cobertura(_OFICIAL, fonte_incompleta) < 0.6
+
+
+def test_cobertura_texto_vazio_nao_quebra():
+    assert cobertura("", "qualquer") == 0.0
+
+
+# -- motor: classificação ---------------------------------------------------
+def _hab(desc: str = _OFICIAL) -> dict:
+    return {
+        "codigo": "EF01CI01",
+        "descricao": desc,
+        "etapa": "ensino_fundamental",
+        "componente": "ciencias",
+    }
+
+
+def test_classifica_concordante_com_bleed():
+    r = comparar(_hab(), {"arbiter_pdf": _rec("arbiter_pdf", _OFICIAL + " lixo de coluna")})
+    assert r.status == STATUS_CONCORDANTE
+    assert r.melhor_cobertura == 1.0
+
+
+def test_classifica_divergente_quando_nenhuma_fonte_sustenta():
+    r = comparar(_hab(), {"arbiter_pdf": _rec("arbiter_pdf", "Texto totalmente diferente aqui.")})
+    assert r.status == STATUS_DIVERGENTE
+    assert r.fontes_divergentes
+
+
+def test_classifica_concordante_se_a_melhor_fonte_sustenta():
+    """Uma fonte diverge e outra concorda ⇒ concordante (melhor cobertura ≥ limiar)."""
+    r = comparar(
+        _hab(),
+        {
+            "mec_portal": _rec("mec_portal", "Coisa diferente."),
+            "arbiter_pdf": _rec("arbiter_pdf", _OFICIAL),
+        },
+    )
+    assert r.status == STATUS_CONCORDANTE
+
+
+def test_classifica_sem_fontes_quando_todas_ausentes():
+    r = comparar(_hab(), {"arbiter_pdf": None, "bncc_mcp_csv": None})
+    assert r.status == STATUS_SEM_FONTES
+    assert r.melhor_cobertura is None
+
+
+def test_comparar_e_deterministico():
+    reg = {"arbiter_pdf": _rec("arbiter_pdf", _OFICIAL)}
+    a = comparar(_hab(), reg)
+    b = comparar(_hab(), reg)
+    assert (a.status, a.melhor_cobertura) == (b.status, b.melhor_cobertura)
+
+
+# -- fontes: offline não faz rede ------------------------------------------
+def test_offline_nao_instancia_rede(tmp_path):
+    """Com --offline e sem cache, o portal MEC fica indisponível (nada de rede)."""
+    fontes = carregar_fontes(("mec_portal",), offline=True, cache_dir=tmp_path)
+    assert fontes == []
+
+
+# -- ledger: idempotência ---------------------------------------------------
+def test_ledger_idempotente():
+    r = comparar(_hab(), {"arbiter_pdf": _rec("arbiter_pdf", _OFICIAL)})
+    l1 = atualizar_ledger({"codigos": {}}, [r], lote=1, hoje="2026-07-11", snapshot_versao="v1")
+    l2 = atualizar_ledger(
+        dict(l1, codigos=dict(l1["codigos"])), [r], lote=1, hoje="2026-07-11", snapshot_versao="v1"
+    )
+    assert l1 == l2
+
+
+def test_selecionar_pula_ja_auditados():
+    habs = [{"codigo": "EF01CI01"}, {"codigo": "EF01CI02"}, {"codigo": "EF01CI03"}]
+    ledger = {"codigos": {"EF01CI01": {"lote": 1}}}
+    sel = selecionar(habs, ledger, n=10, codigos=None, reauditar=False)
+    assert [h["codigo"] for h in sel] == ["EF01CI02", "EF01CI03"]
+
+
+def test_proximo_lote_incrementa():
+    assert proximo_lote({"codigos": {}}) == 1
+    assert proximo_lote({"codigos": {"X": {"lote": 3}, "Y": {"lote": 5}}}) == 6


### PR DESCRIPTION
## Contexto
A Constituição (Princípio IV) exige fidelidade das descrições ao documento oficial. As defesas existentes são **internas** (`audit_extraction.py`, `validate_bncc_coverage.py`) ou de **uma só vez** (`reconcile` contra 2 testemunhas, auditoria 2026-07-06). Faltava um fluxo **repetível, externo, agêntico e incremental** que cruze cada habilidade contra fontes **independentes**.

## O que este PR entrega
Um fluxo que **não altera dados**: cobre o corpus (~1.717 habilidades) aos poucos e produz **relatórios em Markdown** para decisão humana (Princípios IV e VII).

- **Motor determinístico** (`scripts/audit/engine.py`) — classifica por **cobertura** (fração do texto do snapshot sustentada pela testemunha; tolera *bleed* de coluna) + similaridade informativa. Reusa `_norm()` do `reconcile`.
- **Fontes (allowlist)** (`scripts/audit/sources/`) — `arbiter_pdf` (PDF homologado, com cache), `bncc_mcp_csv` (2ª testemunha vendorizada), `mec_portal` (cache-first). Degradação graciosa por fonte.
- **CLI** (`scripts/audit_external.py`) — `--lote/--codigos/--reauditar/--offline`; gera relatório por lote, mantém `audit/ledger.json` e regenera `audit/PROGRESSO.md`.
- **Assessor agêntico** (`.claude/agents/bncc-auditor.md`) — enriquece divergências no próprio `.md` (propõe correção + citação + confiança); **nunca** toca em `data/`.
- **Docs** (`docs/auditoria-externa.md`) e **testes** (`tests/contract/test_audit_external.py`, 12 ✓).
- **`audit/`** — ledger + PROGRESSO + primeiro lote (15 códigos) como semente.

## Garantias
- Não muta `data/` nem o snapshot; correções aprovadas entram **só** pelo `reconcile` existente, após revisão humana.
- Nenhum gate de CI bloqueia por divergência (são achados, não erros).
- `ruff` + `black` limpos; `pytest tests/contract/test_audit_external.py` → 12 passed. Determinismo verificado (mesmos inputs → relatório byte-idêntico).

🤖 Generated with [Claude Code](https://claude.com/claude-code)