### PR TITLE
chore(deploy): exclui audit/ do Cloud Build (ferramenta local)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -28,6 +28,10 @@ specs/
 .specify/
 .claude/
 
+# Auditoria externa de fidelidade: ferramenta LOCAL (relatorios/ledger/cache).
+# Nao e importada em runtime nem usada no build — nao sobe para o Cloud Build.
+audit/
+
 # Dentro de data/: manter apenas bncc_v1.json; excluir DBs, vetores e PDFs grandes
 data/*.db
 data/*.db-*


### PR DESCRIPTION
Mantém a ferramenta de auditoria externa de fidelidade fora da imagem do Cloud Run.

`audit/` (relatórios/ledger) é usado **só localmente** — não é importado pelo runtime (`app/`) nem usado no build. Adiciona-o ao `.gcloudignore`, que é o mecanismo canônico do projeto para controlar o que sobe ao `gcloud builds submit` (o `.dockerignore` é deliberadamente gitignored aqui).

Sem impacto em runtime/deploy: nenhuma dependência nova, `CMD` inalterado, build de embeddings inalterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)