### PR TITLE
docs(admin): runner local do painel + guia de segurança

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -160,6 +160,8 @@ outra moeda, defina `USD_BRL_RATE` para converter.
 
 ## Painel de administração (`/admin`) — isolamento e acesso
 
+> Guia detalhado (uso local, senhas, por que é seguro em open-source, IAP): **`deploy/admin/README.md`**.
+
 O painel de admin é **governado por `ADMIN_MODE`** (default `false`). Só é MONTADO quando habilitado;
 o serviço público de produção **não o monta** (superfície de admin pública = zero). Autenticação:
 

--- a/deploy/admin/.gitignore
+++ b/deploy/admin/.gitignore
@@ -1,0 +1,4 @@
+# Arquivos de runtime do local-admin.ps1 (não versionar)
+bin/
+.logs/
+.local-admin.pids

--- a/deploy/admin/README.md
+++ b/deploy/admin/README.md
@@ -1,0 +1,106 @@
+# Painel de administração (`/admin`)
+
+Ferramentas e operação do painel interno de **business intelligence** da plataforma
+(contas, API keys, uso). O painel é isolado do site público e **nunca** é exposto por
+padrão. Este diretório contém:
+
+- **`local-admin.ps1`** — sobe o painel na sua máquina, contra o banco de **produção**,
+  por um túnel autenticado (uso do dia a dia).
+- **`deploy-admin.ps1`** — provisiona um serviço remoto isolado atrás do **Google IAP**
+  (só quando você precisar de acesso web; ver a seção final).
+
+> ## Nota de segurança (projeto open-source)
+> **Nenhum segredo real vive neste repositório.** As senhas/chaves de produção
+> (`DB_PASSWORD`, `SECRET_KEY`, credenciais OAuth) ficam no **Google Secret Manager** e
+> são lidas em tempo de execução. O único valor "sensível-aparente" versionado é a
+> **senha padrão do painel em modo dev** (abaixo) — e ela **não concede nenhum acesso a
+> produção** (ver "Por que isso é seguro").
+
+---
+
+## Uso local (recomendado)
+
+Pré-requisitos: `gcloud` autenticado como dono do projeto (`fabio@expertia.dev.br`), ADC
+presente (`gcloud auth application-default login`) e o `venv` do projeto criado.
+
+Num terminal **PowerShell**, a partir da raiz do repositório:
+
+```powershell
+.\deploy\admin\local-admin.ps1 start      # sobe túnel + app e abre o navegador
+.\deploy\admin\local-admin.ps1 status     # mostra o que está no ar
+.\deploy\admin\local-admin.ps1 stop       # derruba tudo
+.\deploy\admin\local-admin.ps1 restart
+```
+
+O `start` faz tudo sozinho: baixa o `cloud-sql-proxy` (uma vez, em `bin/`), lê o
+`DB_PASSWORD` do Secret Manager, sobe o túnel para o Cloud SQL de produção e o app com
+`ADMIN_MODE=1`, e abre `http://127.0.0.1:8000/admin`.
+
+### Senhas
+
+| O que | Onde se usa | Valor |
+|---|---|---|
+| **Senha do painel** (`-AdminPassword`) | login em `/admin/login` | **`bncc-admin-local`** (default dev) |
+| **Senha do banco** (`DB_PASSWORD`) | conexão ao Cloud SQL | **sem default** — lida do Secret Manager automaticamente |
+
+Trocar a senha do painel nesta sessão:
+
+```powershell
+.\deploy\admin\local-admin.ps1 start -AdminPassword "uma-senha-sua"
+```
+
+### Se o `gcloud` pedir *reauthentication*
+
+Em execução não-interativa o `gcloud` pode falhar com
+`cannot prompt during non-interactive execution`. Soluções:
+
+1. Rode `gcloud auth login` uma vez e tente de novo; **ou**
+2. Forneça a senha do banco pela env (pula o `gcloud`):
+   ```powershell
+   $env:BNCC_ADMIN_DB_PASSWORD = "<senha-do-banco>"
+   .\deploy\admin\local-admin.ps1 start
+   ```
+
+---
+
+## Por que isso é seguro (mesmo com a senha padrão pública)
+
+A senha `bncc-admin-local` está no código, mas **não abre nada em produção**:
+
+- **É dev-only.** `admin_password_enabled` é `False` quando `ENVIRONMENT=production`
+  (ver `app/core/config.py`) — em produção **só** existe login por Google.
+- **É local-only.** O painel só é montado com `ADMIN_MODE=1`, que o deploy público
+  **não** define. Em `bncc.api.br/admin` (e na URL crua do Cloud Run) a rota é **404**.
+- **Exige credenciais reais para servir dados.** O `local-admin.ps1` só lê o banco de
+  produção através do `cloud-sql-proxy`, que autentica com **as suas credenciais Google
+  (IAM/ADC)**. Quem clonar o repo e usar `bncc-admin-local` não alcança banco nenhum sem
+  ter, antes, acesso IAM ao projeto `api-bncc`.
+
+Em produção/remoto o acesso é **identidade por pessoa**: Google Sign-In restrito a
+`ADMIN_ALLOWED_EMAILS`, com MFA da conta Google. A senha compartilhada é proibida lá
+(fail-fast no boot).
+
+---
+
+## Acesso remoto (opcional) — serviço isolado atrás do Google IAP
+
+Quando/se for preciso acesso web ao painel, `deploy-admin.ps1` provisiona um serviço
+Cloud Run **separado** (`bncc-admin`) com ingress interno + Load Balancer HTTPS +
+**Identity-Aware Proxy**, mapeado em `admin.bncc.api.br`. A autorização é feita via
+`gcloud`/IAM (só e-mails com `roles/iap.httpsResourceAccessor` passam), e o app ainda
+reaplica a allowlist `ADMIN_ALLOWED_EMAILS` — **dois portões independentes**.
+
+```powershell
+.\deploy\admin\deploy-admin.ps1 -AllowedEmails "voce@dominio.com,colega@dominio.com" `
+  -IapClientId <oauth-client-id-do-IAP> -IapClientSecret <secret>
+```
+
+Passos manuais (só-Console) e detalhes: ver os comentários no topo de `deploy-admin.ps1`
+e a seção "Painel de administração" em `deploy/README.md`.
+
+---
+
+## Arquivos de runtime (não versionados)
+
+`bin/` (binário do proxy), `.logs/` e `.local-admin.pids` são gerados em execução e estão
+no `.gitignore` deste diretório.

--- a/deploy/admin/local-admin.ps1
+++ b/deploy/admin/local-admin.ps1
@@ -1,0 +1,165 @@
+<#
+  deploy/admin/local-admin.ps1 - Painel /admin LOCAL contra o banco de PRODUCAO.
+
+  Sobe, na sua maquina, o app com o painel /admin habilitado, conectado ao Cloud SQL
+  de producao por um tunel autenticado (cloud-sql-proxy + suas credenciais IAM). Nada
+  e exposto na internet: o painel roda so em 127.0.0.1. O admin_service e somente-leitura.
+
+  Uso:
+    ./deploy/admin/local-admin.ps1 start      # sobe proxy + app e abre o navegador
+    ./deploy/admin/local-admin.ps1 stop       # derruba app + proxy
+    ./deploy/admin/local-admin.ps1 status     # mostra o que esta no ar
+    ./deploy/admin/local-admin.ps1 restart
+
+  Parametros (opcionais):
+    -AdminPassword <senha>   Senha do painel (dev). Default: "bncc-admin-local".
+    -Port 8000               Porta do app.       -ProxyPort 5433   Porta do proxy.
+
+  Pre-requisitos: gcloud autenticado como dono do projeto (fabio@expertia.dev.br) com
+  ADC presente (gcloud auth application-default login), e o venv do projeto criado.
+  Se o gcloud pedir reauthentication, rode 'gcloud auth login' uma vez no seu terminal.
+  Alternativa: exporte $env:BNCC_ADMIN_DB_PASSWORD antes de 'start' para pular o gcloud.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)]
+  [ValidateSet("start", "stop", "status", "restart")]
+  [string]$Action = "status",
+  [string]$AdminPassword = "bncc-admin-local",  # pragma: allowlist secret (dev-only, local-only)
+  [int]$Port      = 8000,
+  [int]$ProxyPort = 5433,
+  [string]$Project        = "api-bncc",
+  [string]$ConnectionName = "api-bncc:southamerica-east1:bncc-pg",
+  [string]$DbUser = "bncc_app",
+  [string]$DbName = "bncc"
+)
+
+$ErrorActionPreference = "Stop"
+$Here     = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $Here "..\..")
+$BinDir   = Join-Path $Here "bin"
+$Proxy    = Join-Path $BinDir "cloud-sql-proxy.exe"
+$PidFile  = Join-Path $Here ".local-admin.pids"
+$LogDir   = Join-Path $Here ".logs"
+$VenvPy   = Join-Path $RepoRoot "venv\Scripts\python.exe"
+$ProxyVersion = "v2.14.3"
+
+function Info($m) { Write-Host "==> $m" -ForegroundColor Cyan }
+function Warn($m) { Write-Host "!!  $m" -ForegroundColor Yellow }
+function Ok($m)   { Write-Host "OK  $m" -ForegroundColor Green }
+
+function Get-PortPid([int]$p) {
+  $c = Get-NetTCPConnection -LocalPort $p -State Listen -ErrorAction SilentlyContinue
+  if ($c) { return ($c.OwningProcess | Select-Object -Unique) }
+  return $null
+}
+
+function Ensure-Proxy {
+  if (Test-Path $Proxy) { return }
+  Info "Baixando cloud-sql-proxy $ProxyVersion (uma vez)"
+  New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+  $url = "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/$ProxyVersion/cloud-sql-proxy.x64.exe"
+  Invoke-WebRequest -Uri $url -OutFile $Proxy
+  Ok "Proxy baixado em $Proxy"
+}
+
+function Do-Start {
+  if (-not (Test-Path $VenvPy)) { throw "venv nao encontrado em $VenvPy - crie o ambiente do projeto primeiro." }
+  if (Get-PortPid $Port) { Warn "Ja ha algo na porta $Port (app). Rode 'stop' antes ou use outra -Port."; return }
+  Ensure-Proxy
+  New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+  # Senha do banco: por padrao vem do Secret Manager (nunca fica em disco). Se a env
+  # BNCC_ADMIN_DB_PASSWORD ja estiver setada, usa ela e pula o gcloud (util quando o
+  # gcloud esta pedindo reauth non-interativo ou em automacao).
+  if (-not [string]::IsNullOrWhiteSpace($env:BNCC_ADMIN_DB_PASSWORD)) {
+    Info "Usando DB_PASSWORD de BNCC_ADMIN_DB_PASSWORD (fornecida pelo ambiente)"
+    $dbPass = $env:BNCC_ADMIN_DB_PASSWORD
+  } else {
+    Info "Lendo DB_PASSWORD do Secret Manager ($Project)"
+    $env:CLOUDSDK_BILLING_QUOTA_PROJECT = $Project
+    $dbPass = (gcloud secrets versions access latest --secret=DB_PASSWORD --project $Project 2>$null)
+  }
+  if ([string]::IsNullOrWhiteSpace($dbPass)) {
+    throw "Falha ao obter DB_PASSWORD. Rode 'gcloud auth login' (reauth) ou exporte BNCC_ADMIN_DB_PASSWORD."
+  }
+
+  # 1) cloud-sql-proxy (usa ADC do gcloud)
+  Info "Subindo cloud-sql-proxy em 127.0.0.1:$ProxyPort"
+  $proxyProc = Start-Process -FilePath $Proxy `
+    -ArgumentList @("--address", "127.0.0.1", "--port", "$ProxyPort", $ConnectionName) `
+    -RedirectStandardOutput (Join-Path $LogDir "proxy.out.log") `
+    -RedirectStandardError  (Join-Path $LogDir "proxy.err.log") `
+    -WindowStyle Hidden -PassThru
+
+  $ready = $false
+  foreach ($i in 1..15) {
+    Start-Sleep -Milliseconds 500
+    if (Get-PortPid $ProxyPort) { $ready = $true; break }
+  }
+  if (-not $ready) { Warn "Proxy nao subiu - veja $LogDir\proxy.err.log"; Stop-Process -Id $proxyProc.Id -Force -ErrorAction SilentlyContinue; return }
+
+  # 2) app (uvicorn) - painel ligado, senha do banco injetada pelo config via placeholder
+  Info "Subindo o app (painel /admin) em http://127.0.0.1:$Port"
+  $env:ENVIRONMENT    = "development"
+  $env:ADMIN_MODE     = "1"
+  $env:ADMIN_PASSWORD = $AdminPassword
+  $env:DATABASE_URL   = "postgresql+asyncpg://${DbUser}:__DB_PASSWORD__@127.0.0.1:${ProxyPort}/${DbName}"
+  $env:DB_PASSWORD    = $dbPass
+  $env:LOG_LEVEL      = "INFO"
+  $appProc = Start-Process -FilePath $VenvPy `
+    -ArgumentList @("-m", "uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "$Port") `
+    -WorkingDirectory $RepoRoot `
+    -RedirectStandardOutput (Join-Path $LogDir "app.out.log") `
+    -RedirectStandardError  (Join-Path $LogDir "app.err.log") `
+    -WindowStyle Hidden -PassThru
+
+  "$($proxyProc.Id) $($appProc.Id)" | Set-Content -Path $PidFile -Encoding ascii
+
+  $up = $false
+  foreach ($i in 1..25) {
+    Start-Sleep -Milliseconds 800
+    try {
+      $r = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/admin/login" -UseBasicParsing -TimeoutSec 3
+      if ($r.StatusCode -eq 200) { $up = $true; break }
+    } catch { }
+  }
+  if (-not $up) { Warn "App demorou a responder - veja $LogDir\app.err.log (talvez ainda carregando embeddings)." }
+
+  Ok "Painel no ar: http://127.0.0.1:$Port/admin  (senha: $AdminPassword)"
+  Start-Process "http://127.0.0.1:$Port/admin/login"
+}
+
+function Do-Stop {
+  $killed = @()
+  if (Test-Path $PidFile) {
+    foreach ($id in ((Get-Content $PidFile) -split "\s+")) {
+      if ($id -and (Get-Process -Id $id -ErrorAction SilentlyContinue)) {
+        Stop-Process -Id $id -Force -ErrorAction SilentlyContinue; $killed += $id
+      }
+    }
+    Remove-Item $PidFile -ErrorAction SilentlyContinue
+  }
+  # fallback: mata por porta (caso o PID file esteja obsoleto)
+  foreach ($p in @($Port, $ProxyPort)) {
+    $pp = Get-PortPid $p
+    if ($pp) { $pp | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue; $killed += $_ } }
+  }
+  if ($killed.Count) { Ok "Encerrados PIDs: $($killed -join ', ')" } else { Info "Nada rodando." }
+}
+
+function Do-Status {
+  $appPid   = Get-PortPid $Port
+  $proxyPid = Get-PortPid $ProxyPort
+  Write-Host "App  (porta $Port):      " -NoNewline
+  if ($appPid)   { Ok "no ar (PID $appPid) -> http://127.0.0.1:$Port/admin" } else { Warn "parado" }
+  Write-Host "Proxy (porta $ProxyPort): " -NoNewline
+  if ($proxyPid) { Ok "no ar (PID $proxyPid) -> $ConnectionName" } else { Warn "parado" }
+}
+
+switch ($Action) {
+  "start"   { Do-Start }
+  "stop"    { Do-Stop }
+  "restart" { Do-Stop; Start-Sleep -Seconds 1; Do-Start }
+  "status"  { Do-Status }
+}


### PR DESCRIPTION
## Resumo
Ferramenta e documentação para operar o painel `/admin` **localmente** contra o banco de produção, e um guia de segurança pensado para um projeto **open-source**.

## O que entra
- **`deploy/admin/local-admin.ps1`** — `start` / `stop` / `status` / `restart`. Baixa o `cloud-sql-proxy` sob demanda, lê `DB_PASSWORD` do Secret Manager (nunca em disco, injeta via placeholder), sobe túnel + app com `ADMIN_MODE=1` e abre `http://127.0.0.1:8000/admin`. Fallback `BNCC_ADMIN_DB_PASSWORD` para quando o gcloud exige reauth não-interativo.
- **`deploy/admin/README.md`** — uso local, senhas e a seção **"por que é seguro"**.
- **`deploy/admin/.gitignore`** — ignora runtime (`bin/`, `.logs/`, `.local-admin.pids`).
- Ponteiro em `deploy/README.md`.

## Segurança (open-source)
- **Nenhum segredo real versionado** — `DB_PASSWORD`/`SECRET_KEY`/OAuth ficam no Secret Manager.
- A única senha no repo é `bncc-admin-local` (marcada `pragma: allowlist secret`), **dev-only e local-only**: não abre nada em produção (`admin_password_enabled=False` em prod; rota 404 sem `ADMIN_MODE`; ler o banco exige credenciais IAM do operador).

Validado end-to-end localmente: `start` sobe proxy+app (`/admin/login` → 200), `stop` derruba ambos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)