### PR TITLE
feat(landing): seção pública de transparência de uso da plataforma

### DIFF
--- a/app/models/platform.py
+++ b/app/models/platform.py
@@ -181,3 +181,47 @@ class AccountAnalyticsResponse(BaseModel):
     deterministic_requests: int = Field(..., description="Chamadas determinísticas na janela")
     active_keys: int
     new_keys_last_7d: int = Field(..., description="Keys ativas criadas nos últimos 7 dias")
+
+
+# --------------------------------------------------------------------------- #
+# Transparência pública de uso (seção da landing — SSR)
+# --------------------------------------------------------------------------- #
+class PublicUsagePoint(BaseModel):
+    """Um ponto da série diária pública (agregada de TODA a plataforma)."""
+
+    date: date
+    total: int = Field(..., description="Requisições autorizadas no dia (toda a plataforma)")
+
+
+class PublicUsageWindow(BaseModel):
+    """Uma janela temporal pré-computada (7/30/90 dias) para o filtro público.
+
+    Pré-renderizar as três janelas de uma vez permite ao cliente alternar o filtro
+    sem nenhuma requisição nova (Princípio VII — custo previsível): o servidor faz
+    uma varredura, cacheada, e o toggle é só CSS/DOM.
+    """
+
+    days: int
+    series: list[PublicUsagePoint]
+    total_requests: int = Field(0, description="Total de requisições na janela")
+    daily_average: int = Field(0, description="Média diária de requisições na janela")
+    peak: int = Field(0, description="Pico diário de requisições na janela")
+
+
+class PublicUsageSummary(BaseModel):
+    """Transparência pública de uso: séries por janela + KPIs de adoção.
+
+    Só métricas **agregadas** de toda a plataforma — nunca por conta, IP ou key, e
+    **sem taxa de erro** (isso é sinal operacional para atacante e fica restrito ao
+    painel /admin). Alimenta a seção "Transparência" da landing (SSR).
+    """
+
+    has_data: bool = Field(False, description="Falso quando não há nenhuma requisição registrada")
+    default_window: int = Field(30, description="Janela exibida por padrão (dias)")
+    windows: list[PublicUsageWindow] = Field(default_factory=list)
+    total_to_date: int = Field(0, description="Requisições acumuladas desde o início")
+    period_start: date | None = Field(None, description="Primeiro dia com tráfego registrado")
+    developers: int = Field(
+        0, description="Contas distintas que já fizeram ao menos uma requisição"
+    )
+    active_keys: int = Field(0, description="API keys ativas na plataforma")

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -27,11 +27,19 @@ from app.models.platform import (
     AccountUsageResponse,
     BucketUsage,
     KeyUsageResponse,
+    PublicUsagePoint,
+    PublicUsageSummary,
+    PublicUsageWindow,
     UsageDailyPoint,
 )
 
 # Janela padrão do painel de BI (últimos N dias, inclusive hoje).
 ANALYTICS_WINDOW_DAYS = 30
+
+# Janelas oferecidas no filtro público da landing (dias). Todas são pré-computadas
+# de uma vez; o cliente alterna sem requisição nova.
+PUBLIC_USAGE_WINDOWS: tuple[int, ...] = (7, 30, 90)
+PUBLIC_USAGE_DEFAULT_WINDOW = 30
 
 
 def _now() -> datetime:
@@ -364,4 +372,88 @@ async def account_analytics(
         deterministic_requests=deterministic_requests,
         active_keys=active_keys,
         new_keys_last_7d=new_keys_last_7d,
+    )
+
+
+async def public_usage_summary(
+    session: AsyncSession,
+    windows: tuple[int, ...] = PUBLIC_USAGE_WINDOWS,
+    default_window: int = PUBLIC_USAGE_DEFAULT_WINDOW,
+) -> PublicUsageSummary:
+    """Séries por janela + KPIs de adoção para a seção "Transparência" da landing.
+
+    Espelha ``cost_service.public_cost_summary``: uma única varredura de
+    ``usage_records`` (na maior janela pedida) monta a série diária agregada de TODA
+    a plataforma, da qual fatiamos cada janela (7/30/90). Só totais agregados —
+    nunca por conta/IP/key e **sem taxa de erro** (sinal operacional; fica no /admin).
+    Puro em relação a HTTP: recebe a sessão, devolve o modelo Pydantic.
+    """
+    windows = tuple(sorted({w for w in windows if w > 0})) or (default_window,)
+    today = _day_window_start()
+    max_days = max(windows)
+    max_start = today - timedelta(days=max_days - 1)
+
+    # Uma varredura: total diário da plataforma (soma dos dois buckets) na maior janela.
+    rows = (
+        await session.execute(
+            select(UsageRecord.window_start, func.sum(UsageRecord.count))
+            .where(UsageRecord.window_start >= max_start)
+            .group_by(UsageRecord.window_start)
+        )
+    ).all()
+    per_day: dict[date, int] = {}
+    for ws, total in rows:
+        d = _as_date(ws)
+        per_day[d] = per_day.get(d, 0) + int(total or 0)
+
+    def _window(days: int) -> PublicUsageWindow:
+        start = (today - timedelta(days=days - 1)).date()
+        series = [
+            PublicUsagePoint(date=d, total=per_day.get(d, 0))
+            for d in (start + timedelta(days=i) for i in range(days))
+        ]
+        total = sum(p.total for p in series)
+        return PublicUsageWindow(
+            days=days,
+            series=series,
+            total_requests=total,
+            daily_average=round(total / days) if days else 0,
+            peak=max((p.total for p in series), default=0),
+        )
+
+    window_models = [_window(d) for d in windows]
+
+    # Totais all-time e adoção (agregações enxutas, uma linha cada).
+    total_to_date = int(
+        (await session.execute(select(func.coalesce(func.sum(UsageRecord.count), 0)))).scalar_one()
+        or 0
+    )
+    earliest = (await session.execute(select(func.min(UsageRecord.window_start)))).scalar_one()
+    developers = int(
+        (
+            await session.execute(
+                select(func.count(func.distinct(ApiKey.account_id)))
+                .select_from(UsageRecord)
+                .join(ApiKey, ApiKey.id == UsageRecord.api_key_id)
+            )
+        ).scalar_one()
+        or 0
+    )
+    active_keys = int(
+        (
+            await session.execute(
+                select(func.count()).select_from(ApiKey).where(ApiKey.status == ApiKeyStatus.active)
+            )
+        ).scalar_one()
+        or 0
+    )
+
+    return PublicUsageSummary(
+        has_data=total_to_date > 0,
+        default_window=default_window if default_window in windows else windows[0],
+        windows=window_models,
+        total_to_date=total_to_date,
+        period_start=_as_date(earliest) if earliest is not None else None,
+        developers=developers,
+        active_keys=active_keys,
     )

--- a/app/web/charts.py
+++ b/app/web/charts.py
@@ -167,6 +167,96 @@ def build_usage_chart(series: list) -> UsageChart:
 
 
 # --------------------------------------------------------------------------- #
+# Gráfico de área de série única — uso público diário (transparência)
+# --------------------------------------------------------------------------- #
+@dataclass
+class UsagePoint:
+    x: float
+    y: float
+    label: str  # dd/mm
+    total: int
+
+
+@dataclass
+class PublicUsageChart:
+    width: int = _WIDTH
+    height: int = _HEIGHT
+    baseline: float = _HEIGHT - _PAD_B
+    max_value: int = 0
+    has_data: bool = False
+    line: str = ""
+    area: str = ""
+    points: list[UsagePoint] = field(default_factory=list)
+    y_ticks: list[AxisTick] = field(default_factory=list)
+    x_ticks: list[AxisTick] = field(default_factory=list)
+
+
+def build_public_usage_chart(series: list) -> PublicUsageChart:
+    """Monta a geometria do gráfico de área público (uma série: requisições/dia).
+
+    Cada item de ``series`` expõe ``date`` e ``total``. Determinístico e testável:
+    mesma escala "bonita" e mapeamento invertido do gráfico do painel, mas com uma
+    única linha (sem separar sucesso/erro — Princípio da mínima exposição pública).
+    """
+    chart = PublicUsageChart()
+    n = len(series)
+    if n == 0:
+        return chart
+
+    peak = max((p.total for p in series), default=0)
+    chart.has_data = peak > 0
+
+    ticks = 4
+    nice_range = _nice_num(max(peak, 1), round_up=True)
+    step = _nice_num(nice_range / ticks, round_up=True)
+    max_value = int(step * ticks)
+    if max_value < 4:
+        max_value = 4
+        step = max_value / ticks
+    chart.max_value = max_value
+
+    plot_w = _WIDTH - _PAD_L - _PAD_R
+    plot_h = _HEIGHT - _PAD_T - _PAD_B
+
+    def x_at(i: int) -> float:
+        if n == 1:
+            return _PAD_L + plot_w / 2
+        return _PAD_L + plot_w * i / (n - 1)
+
+    def y_at(v: int) -> float:
+        return _PAD_T + plot_h * (1 - v / max_value)
+
+    pts: list[str] = []
+    for i, p in enumerate(series):
+        x = round(x_at(i), 2)
+        y = round(y_at(p.total), 2)
+        pts.append(f"{x},{y}")
+        chart.points.append(UsagePoint(x=x, y=y, label=_fmt_date(p.date), total=p.total))
+
+    baseline = chart.baseline
+    first_x = chart.points[0].x
+    last_x = chart.points[-1].x
+    chart.line = " ".join(pts)
+    chart.area = f"M{first_x},{baseline} L" + " L".join(pts) + f" L{last_x},{baseline} Z"
+
+    i = 0
+    while i <= ticks:
+        v = int(round(step * i))
+        chart.y_ticks.append(AxisTick(pos=round(y_at(v), 2), label=_fmt_int(v)))
+        i += 1
+
+    max_labels = 7
+    stride = max(1, math.ceil(n / max_labels))
+    seen: set[int] = set()
+    for idx in list(range(0, n, stride)) + [n - 1]:
+        if idx in seen:
+            continue
+        seen.add(idx)
+        chart.x_ticks.append(AxisTick(pos=round(x_at(idx), 2), label=chart.points[idx].label))
+    return chart
+
+
+# --------------------------------------------------------------------------- #
 # Gráfico de barras empilhadas — custo mensal por serviço (transparência)
 # --------------------------------------------------------------------------- #
 @dataclass

--- a/app/web/landing.py
+++ b/app/web/landing.py
@@ -9,7 +9,9 @@ histórias, conforme tasks.md Fase 7).
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -44,31 +46,90 @@ _SITEMAP_ENTRIES = [
 ]
 
 
-async def _cost_context() -> dict:
-    """Monta o contexto da seção "Transparência de custos" de forma resiliente.
+# Cache em processo do contexto de transparência (uso + custos). A landing é
+# pública e pode receber rajadas; sem cache, cada page-load bateria no banco. Com
+# TTL curto (10 min), é 1 consulta por janela independentemente do tráfego —
+# custo previsível (Princípio VII) sem depender do CDN (que é frágil, ver memória
+# firebase-hosting-cache). Os filtros de janela não geram requisição: as três
+# janelas são pré-renderizadas e o cliente só alterna no DOM.
+_TRANSPARENCY_TTL_SECONDS = 600
+_transparency_lock = asyncio.Lock()
+_transparency_cached_ctx: dict | None = None
+_transparency_cached_at: float = 0.0
 
-    Lê apenas o banco (nunca o BigQuery). Qualquer falha (banco indisponível,
-    tabela vazia) degrada para uma landing sem a seção — nunca quebra a página
-    pública (Princípio VII). Import tardio para não acoplar o web router à camada
-    de dados na importação.
+
+def reset_transparency_cache() -> None:
+    """Invalida o cache (usado nos testes; seguro em runtime)."""
+    global _transparency_cached_ctx, _transparency_cached_at
+    _transparency_cached_ctx = None
+    _transparency_cached_at = 0.0
+
+
+async def _build_transparency_context() -> dict:
+    """Monta o contexto das seções de transparência (uso + custos).
+
+    Lê apenas o banco da plataforma (nunca o BigQuery). Cada seção é isolada: uma
+    falha ao montar custos não derruba o uso e vice-versa; qualquer falha degrada
+    para a landing sem a seção — nunca quebra a página pública (Princípio VII).
+    Import tardio para não acoplar o web router à camada de dados na importação.
     """
+    ctx: dict = {
+        "cost_summary": None,
+        "cost_chart": None,
+        "usage_summary": None,
+        "usage_charts": {},
+    }
     try:
         from app.db.base import async_session_factory
-        from app.services import cost_service
-        from app.web.charts import build_cost_chart
+        from app.services import cost_service, usage_service
+        from app.web.charts import build_cost_chart, build_public_usage_chart
 
         async with async_session_factory() as session:
-            summary = await cost_service.public_cost_summary(session)
-        return {"cost_summary": summary, "cost_chart": build_cost_chart(summary.series)}
+            try:
+                summary = await cost_service.public_cost_summary(session)
+                ctx["cost_summary"] = summary
+                ctx["cost_chart"] = build_cost_chart(summary.series)
+            except Exception:
+                logger.exception("Falha ao montar a transparência de custos")
+            try:
+                usage = await usage_service.public_usage_summary(session)
+                ctx["usage_summary"] = usage
+                ctx["usage_charts"] = {
+                    w.days: build_public_usage_chart(w.series) for w in usage.windows
+                }
+            except Exception:
+                logger.exception("Falha ao montar a transparência de uso")
     except Exception:
-        logger.exception("Falha ao montar a transparência de custos")
-        return {"cost_summary": None, "cost_chart": None}
+        logger.exception("Falha ao abrir sessão para a transparência")
+    return ctx
+
+
+async def _transparency_context() -> dict:
+    """Devolve o contexto de transparência com cache TTL (dupla checagem sob lock)."""
+    global _transparency_cached_ctx, _transparency_cached_at
+    now = time.monotonic()
+    if (
+        _transparency_cached_ctx is not None
+        and (now - _transparency_cached_at) < _TRANSPARENCY_TTL_SECONDS
+    ):
+        return _transparency_cached_ctx
+    async with _transparency_lock:
+        now = time.monotonic()
+        if (
+            _transparency_cached_ctx is not None
+            and (now - _transparency_cached_at) < _TRANSPARENCY_TTL_SECONDS
+        ):
+            return _transparency_cached_ctx
+        ctx = await _build_transparency_context()
+        _transparency_cached_ctx = ctx
+        _transparency_cached_at = now
+        return ctx
 
 
 @router.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def landing(request: Request) -> Response:
     """Landing page: proposta de valor, recursos, público-alvo e CTA (SC-008)."""
-    return templates.TemplateResponse(request, "landing.html", await _cost_context())
+    return templates.TemplateResponse(request, "landing.html", await _transparency_context())
 
 
 @router.get("/favicon.ico", include_in_schema=False)

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -38,8 +38,18 @@ def _brl(value: object) -> str:
     return f"R$ {formatted}"
 
 
+def _milhar(value: object) -> str:
+    """Filtro Jinja: agrupa milhar no padrão pt-BR (2500 → '2.500')."""
+    try:
+        n = int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return ""
+    return f"{n:,}".replace(",", ".")
+
+
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR), context_processors=[_seo_context])
 templates.env.filters["brl"] = _brl
+templates.env.filters["milhar"] = _milhar
 
 web_router = APIRouter()
 

--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -799,6 +799,35 @@ input[type="password"]::-ms-clear { display: none; }
 .chart-data summary { cursor: pointer; color: var(--fg-muted); font-size: 0.85rem; min-height: 36px; display: inline-flex; align-items: center; }
 .chart-empty { padding: 2.5rem 1rem; text-align: center; }
 
+/* Transparência (uso + custos na landing) */
+.transparency-block + .transparency-block { margin-top: 3rem; }
+.transparency-subtitle { font-size: 1.2rem; font-weight: 700; margin: 0 0 0.35rem; letter-spacing: -0.01em; }
+.transparency-note { margin: 0; max-width: 44rem; }
+
+/* Filtro de janela (pílulas segmentadas) */
+.chart-filters {
+  display: inline-flex; gap: 0.25rem; padding: 0.25rem;
+  background: var(--bg-sunken); border-radius: 999px;
+}
+.chart-filter {
+  border: 0; background: transparent; color: var(--fg-muted);
+  font: inherit; font-size: 0.82rem; font-weight: 600;
+  padding: 0.4rem 0.85rem; min-height: 40px; border-radius: 999px;
+  cursor: pointer; white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.chart-filter:hover { color: var(--fg); }
+.chart-filter.is-active {
+  background: var(--bg); color: var(--brand); box-shadow: var(--shadow-sm);
+}
+.chart-filter:focus-visible { outline: 3px solid var(--brand); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { .chart-filter { transition: none; } }
+
+.usage-kpis { margin-top: 1.25rem; margin-bottom: 1.5rem; }
+.usage-window-total { margin: 0.85rem 0 0; font-size: 0.9rem; }
+.usage-window-total strong { color: var(--fg); font-variant-numeric: tabular-nums; }
+.usage-window[hidden] { display: none; }
+
 /* Custo por serviço (transparência de custos na landing) */
 .cost-kpis { margin-top: 1.5rem; margin-bottom: 1.5rem; }
 .cost-chart .cost-bar { stroke: var(--bg); stroke-width: 1; transition: opacity 0.15s ease; }

--- a/app/web/templates/landing.html
+++ b/app/web/templates/landing.html
@@ -364,89 +364,183 @@ API keys self-service.{% endblock %}
   </div>
 </section>
 
-<!-- ===================== TRANSPARÊNCIA DE CUSTOS ==================== -->
-{% if cost_chart and cost_chart.has_data %}
+<!-- ========================== TRANSPARÊNCIA ========================= -->
+{% if (usage_summary and usage_summary.has_data) or (cost_chart and cost_chart.has_data) %}
 <section class="section container" id="transparencia" aria-labelledby="transparencia-title">
-  <h2 id="transparencia-title">Transparência de custos</h2>
+  <h2 id="transparencia-title">Transparência</h2>
   <p class="lead">
-    Quanto custa manter a BNCC API no ar. Valores reais faturados pelo Google Cloud,
-    por mês e por serviço, atualizados automaticamente.
+    Código aberto não para no repositório. Aqui ficam o uso real da plataforma e a conta
+    que ela gera — números agregados, sem login, atualizados a cada 10 minutos.
   </p>
 
-  <div class="grid kpi-grid cost-kpis">
-    <div class="kpi">
-      <p class="kpi-label">Total até agora{% if cost_summary and cost_summary.period_start %} · desde {{ cost_summary.period_start.strftime('%m/%Y') }}{% endif %}</p>
-      <p class="kpi-value">{{ cost_summary.total_to_date|brl }}</p>
-    </div>
-    <div class="kpi">
-      <p class="kpi-label">Mês atual</p>
-      <p class="kpi-value">{{ cost_summary.total_month|brl }}</p>
-    </div>
-    {% for item in cost_summary.by_service_to_date %}
-    {% if item.amount > 0 %}
-    <div class="kpi">
-      <p class="kpi-label"><span class="dot cost-seg-{{ item.service.value }}"></span>{{ item.label }}</p>
-      <p class="kpi-value">{{ item.amount|brl }}</p>
-    </div>
-    {% endif %}
-    {% endfor %}
-  </div>
+  {% if usage_summary and usage_summary.has_data %}
+  <div class="transparency-block usage-block">
+    <h3 class="transparency-subtitle">Uso da plataforma</h3>
+    <p class="muted transparency-note">
+      Requisições atendidas, dia a dia. Só o total agregado — nada por usuário, chave ou IP.
+    </p>
 
-  <div class="card chart-card">
-    <div class="chart-head">
-      <div>
-        <p class="chart-title">Custo mensal de infraestrutura</p>
-        <p class="chart-caption muted">Por serviço, em reais (R$)</p>
+    <div class="grid kpi-grid usage-kpis">
+      <div class="kpi">
+        <p class="kpi-label">Requisições no total{% if usage_summary.period_start %} · desde {{ usage_summary.period_start.strftime('%m/%Y') }}{% endif %}</p>
+        <p class="kpi-value">{{ usage_summary.total_to_date|milhar }}</p>
       </div>
-      <ul class="chart-legend cost-legend" aria-hidden="true">
-        {% for item in cost_chart.legend %}
-        <li><span class="dot {{ item.color_class }}"></span>{{ item.label }}</li>
-        {% endfor %}
-      </ul>
+      <div class="kpi">
+        <p class="kpi-label">Desenvolvedores</p>
+        <p class="kpi-value">{{ usage_summary.developers|milhar }}</p>
+      </div>
+      <div class="kpi">
+        <p class="kpi-label">Chaves ativas</p>
+        <p class="kpi-value">{{ usage_summary.active_keys|milhar }}</p>
+      </div>
     </div>
 
-    <div class="chart-wrap">
-      <svg class="usage-chart cost-chart" viewBox="0 0 {{ cost_chart.width }} {{ cost_chart.height }}"
-           role="img" preserveAspectRatio="none"
-           aria-label="Custo mensal de infraestrutura por serviço, em reais. Total acumulado de {{ cost_summary.total_to_date|brl }}.">
-        <!-- gridlines + rótulos do eixo Y -->
-        {% for t in cost_chart.y_ticks %}
-        <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ cost_chart.width - 12 }}" y2="{{ t.pos }}"/>
-        <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
-        {% endfor %}
-        <!-- barras empilhadas (um segmento por serviço) -->
-        {% for bar in cost_chart.bars %}
-          {% for seg in bar.segments %}
-          <rect class="cost-bar {{ seg.color_class }}" x="{{ seg.x }}" y="{{ seg.y }}"
-                width="{{ seg.width }}" height="{{ seg.height }}"><title>{{ seg.title }}</title></rect>
+    <div class="card chart-card usage-card">
+      <div class="chart-head">
+        <div>
+          <p class="chart-title">Requisições por dia</p>
+          <p class="chart-caption muted">Toda a plataforma, agregado</p>
+        </div>
+        <div class="chart-filters" role="group" aria-label="Período do gráfico">
+          {% for w in usage_summary.windows %}
+          <button type="button" class="chart-filter{% if w.days == usage_summary.default_window %} is-active{% endif %}"
+                  data-window-btn="{{ w.days }}"
+                  aria-pressed="{{ 'true' if w.days == usage_summary.default_window else 'false' }}">
+            {{ w.days }} dias
+          </button>
           {% endfor %}
-        {% endfor %}
-        <!-- rótulos do eixo X -->
-        {% for t in cost_chart.x_ticks %}
-        <text class="chart-axis" x="{{ t.pos }}" y="{{ cost_chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
-        {% endfor %}
-      </svg>
+        </div>
+      </div>
+
+      {% for w in usage_summary.windows %}
+      {% set chart = usage_charts[w.days] %}
+      <div class="usage-window" data-window="{{ w.days }}"{% if w.days != usage_summary.default_window %} hidden{% endif %}>
+        <div class="chart-wrap">
+          <svg class="usage-chart" viewBox="0 0 {{ chart.width }} {{ chart.height }}"
+               role="img" preserveAspectRatio="none"
+               aria-label="Requisições por dia nos últimos {{ w.days }} dias. Total de {{ w.total_requests|milhar }} requisições, média de {{ w.daily_average|milhar }} por dia.">
+            {% for t in chart.y_ticks %}
+            <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ chart.width - 12 }}" y2="{{ t.pos }}"/>
+            <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
+            {% endfor %}
+            <path class="chart-area chart-area-total" d="{{ chart.area }}"/>
+            <polyline class="chart-line chart-line-total" points="{{ chart.line }}"/>
+            {% for t in chart.x_ticks %}
+            <text class="chart-axis" x="{{ t.pos }}" y="{{ chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
+            {% endfor %}
+          </svg>
+        </div>
+        <p class="usage-window-total muted">
+          <strong>{{ w.total_requests|milhar }}</strong> requisições em {{ w.days }} dias ·
+          média de <strong>{{ w.daily_average|milhar }}</strong>/dia
+        </p>
+      </div>
+      {% endfor %}
+
+      {% set dw = usage_summary.windows | selectattr('days', 'equalto', usage_summary.default_window) | first %}
+      {% if dw %}
+      <details class="chart-data">
+        <summary>Ver dados em tabela ({{ dw.days }} dias)</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th scope="col">Dia</th><th scope="col">Requisições</th></tr></thead>
+            <tbody>
+              {% for p in dw.series %}
+              <tr><td data-label="Dia">{{ p.date.strftime('%d/%m') }}</td><td data-label="Requisições">{{ p.total|milhar }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+  {% if cost_chart and cost_chart.has_data %}
+  <div class="transparency-block cost-block">
+    <h3 class="transparency-subtitle">Transparência de custos</h3>
+    <p class="muted transparency-note">
+      Quanto custa manter a BNCC API no ar. Valores reais faturados pelo Google Cloud,
+      por mês e por serviço.
+    </p>
+
+    <div class="grid kpi-grid cost-kpis">
+      <div class="kpi">
+        <p class="kpi-label">Total até agora{% if cost_summary and cost_summary.period_start %} · desde {{ cost_summary.period_start.strftime('%m/%Y') }}{% endif %}</p>
+        <p class="kpi-value">{{ cost_summary.total_to_date|brl }}</p>
+      </div>
+      <div class="kpi">
+        <p class="kpi-label">Mês atual</p>
+        <p class="kpi-value">{{ cost_summary.total_month|brl }}</p>
+      </div>
+      {% for item in cost_summary.by_service_to_date %}
+      {% if item.amount > 0 %}
+      <div class="kpi">
+        <p class="kpi-label"><span class="dot cost-seg-{{ item.service.value }}"></span>{{ item.label }}</p>
+        <p class="kpi-value">{{ item.amount|brl }}</p>
+      </div>
+      {% endif %}
+      {% endfor %}
     </div>
 
-    <details class="chart-data">
-      <summary>Ver dados em tabela</summary>
-      <div class="table-wrap">
-        <table>
-          <thead><tr><th scope="col">Mês</th><th scope="col">Total</th></tr></thead>
-          <tbody>
-            {% for bar in cost_chart.bars %}
-            <tr><td data-label="Mês">{{ bar.label }}</td><td data-label="Total">{{ bar.total|brl }}</td></tr>
-            {% endfor %}
-          </tbody>
-        </table>
+    <div class="card chart-card">
+      <div class="chart-head">
+        <div>
+          <p class="chart-title">Custo mensal de infraestrutura</p>
+          <p class="chart-caption muted">Por serviço, em reais (R$)</p>
+        </div>
+        <ul class="chart-legend cost-legend" aria-hidden="true">
+          {% for item in cost_chart.legend %}
+          <li><span class="dot {{ item.color_class }}"></span>{{ item.label }}</li>
+          {% endfor %}
+        </ul>
       </div>
-    </details>
-  </div>
 
-  <p class="notice cost-note">
-    Fonte: faturamento real do Google Cloud (BigQuery billing export), líquido de créditos.
-    É o custo de <strong>infraestrutura</strong> da plataforma — não é dado da BNCC.
-  </p>
+      <div class="chart-wrap">
+        <svg class="usage-chart cost-chart" viewBox="0 0 {{ cost_chart.width }} {{ cost_chart.height }}"
+             role="img" preserveAspectRatio="none"
+             aria-label="Custo mensal de infraestrutura por serviço, em reais. Total acumulado de {{ cost_summary.total_to_date|brl }}.">
+          <!-- gridlines + rótulos do eixo Y -->
+          {% for t in cost_chart.y_ticks %}
+          <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ cost_chart.width - 12 }}" y2="{{ t.pos }}"/>
+          <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
+          {% endfor %}
+          <!-- barras empilhadas (um segmento por serviço) -->
+          {% for bar in cost_chart.bars %}
+            {% for seg in bar.segments %}
+            <rect class="cost-bar {{ seg.color_class }}" x="{{ seg.x }}" y="{{ seg.y }}"
+                  width="{{ seg.width }}" height="{{ seg.height }}"><title>{{ seg.title }}</title></rect>
+            {% endfor %}
+          {% endfor %}
+          <!-- rótulos do eixo X -->
+          {% for t in cost_chart.x_ticks %}
+          <text class="chart-axis" x="{{ t.pos }}" y="{{ cost_chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
+          {% endfor %}
+        </svg>
+      </div>
+
+      <details class="chart-data">
+        <summary>Ver dados em tabela</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th scope="col">Mês</th><th scope="col">Total</th></tr></thead>
+            <tbody>
+              {% for bar in cost_chart.bars %}
+              <tr><td data-label="Mês">{{ bar.label }}</td><td data-label="Total">{{ bar.total|brl }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+
+    <p class="notice cost-note">
+      Fonte: faturamento real do Google Cloud (BigQuery billing export), líquido de créditos.
+      É o custo de <strong>infraestrutura</strong> da plataforma — não é dado da BNCC.
+    </p>
+  </div>
+  {% endif %}
 </section>
 {% endif %}
 
@@ -534,6 +628,26 @@ API keys self-service.{% endblock %}
         var original = btn.textContent;
         btn.textContent = "Copiado";
         setTimeout(function () { btn.textContent = original; }, 2500);
+      });
+    });
+  })();
+
+  // Filtro de janela do gráfico de uso: as três janelas já vêm renderizadas do
+  // servidor, então alternar é só mostrar/ocultar — nenhuma requisição nova.
+  (function () {
+    var buttons = document.querySelectorAll(".chart-filter[data-window-btn]");
+    if (!buttons.length) return;
+    buttons.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var days = btn.getAttribute("data-window-btn");
+        buttons.forEach(function (b) {
+          var on = b === btn;
+          b.classList.toggle("is-active", on);
+          b.setAttribute("aria-pressed", on ? "true" : "false");
+        });
+        document.querySelectorAll(".usage-window[data-window]").forEach(function (win) {
+          win.hidden = win.getAttribute("data-window") !== days;
+        });
       });
     });
   })();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,15 @@ def _reset_rate_limiters():
     yield
 
 
+@pytest.fixture(autouse=True)
+def _reset_transparency_cache():
+    """Invalida o cache TTL da landing entre testes (estado de módulo, como os limiters)."""
+    from app.web.landing import reset_transparency_cache
+
+    reset_transparency_cache()
+    yield
+
+
 @pytest.fixture
 def client():
     with TestClient(app) as test_client:

--- a/tests/integration/test_landing_transparency.py
+++ b/tests/integration/test_landing_transparency.py
@@ -1,0 +1,84 @@
+"""
+Testes de integração da seção "Transparência" (uso) na landing.
+
+Cobre: a seção de uso aparece com dados agregados quando há tráfego; o filtro de
+janela (7/30/90) é renderizado; e uma falha ao montar o uso NÃO derruba a landing
+(degradação graciosa — Princípio VII). A taxa de erro nunca aparece na página
+pública (fica no /admin).
+"""
+
+from __future__ import annotations
+
+from app.core.security import generate_api_key, hash_password
+from app.db.base import async_session_factory
+from app.db.tables import ApiKey, ApiKeyStatus, DeveloperAccount, UsageBucket, UsageRecord
+from app.services.usage_service import _day_window_start
+
+
+async def _seed_usage() -> None:
+    async with async_session_factory() as session:
+        account = DeveloperAccount(
+            email="uso@example.com",
+            password_hash=hash_password("senha-forte-123"),
+            email_verified=True,
+        )
+        session.add(account)
+        await session.commit()
+        await session.refresh(account)
+
+        _full, prefix, key_hash = generate_api_key()
+        key = ApiKey(
+            account_id=account.id,
+            name="k",
+            prefix=prefix,
+            key_hash=key_hash,
+            status=ApiKeyStatus.active,
+        )
+        session.add(key)
+        await session.commit()
+        await session.refresh(key)
+
+        session.add(
+            UsageRecord(
+                api_key_id=key.id,
+                bucket=UsageBucket.deterministic,
+                window_start=_day_window_start(),
+                count=1234,
+            )
+        )
+        await session.commit()
+
+
+async def test_landing_shows_usage_section_when_seeded(async_client):
+    await _seed_usage()
+    resp = await async_client.get("/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'id="transparencia"' in body
+    assert "Uso da plataforma" in body
+    # Filtro de janela renderizado no servidor (sem depender de JS).
+    assert 'data-window-btn="7"' in body
+    assert 'data-window-btn="90"' in body
+    # Volume agregado formatado em pt-BR.
+    assert "1.234" in body
+    # A página pública NÃO expõe taxa de erro/sucesso (fica no /admin).
+    assert "taxa de sucesso" not in body.lower()
+
+
+async def test_landing_hides_usage_section_when_empty(async_client):
+    resp = await async_client.get("/")
+    assert resp.status_code == 200
+    assert "Uso da plataforma" not in resp.text
+
+
+async def test_landing_resilient_to_usage_failure(async_client, monkeypatch):
+    await _seed_usage()
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("banco indisponível")
+
+    monkeypatch.setattr("app.services.usage_service.public_usage_summary", _boom)
+    resp = await async_client.get("/")
+    # A landing continua respondendo 200, apenas sem a seção de uso.
+    assert resp.status_code == 200
+    assert "Uso da plataforma" not in resp.text

--- a/tests/unit/test_charts.py
+++ b/tests/unit/test_charts.py
@@ -12,8 +12,8 @@ from datetime import date, timedelta
 import pytest
 from app.db.tables import CostService
 from app.models.cost import SERVICE_LABELS, SERVICE_ORDER, CostMonthPoint, CostServiceAmount
-from app.models.platform import UsageDailyPoint
-from app.web.charts import build_cost_chart, build_usage_chart
+from app.models.platform import PublicUsagePoint, UsageDailyPoint
+from app.web.charts import build_cost_chart, build_public_usage_chart, build_usage_chart
 
 
 def _series(values: list[tuple[int, int]], start: date | None = None) -> list[UsageDailyPoint]:
@@ -72,6 +72,55 @@ def test_single_point_is_centered():
     chart = build_usage_chart(_series([(50, 40)]))
     assert len(chart.points) == 1
     # Ponto único fica no centro horizontal da área de plotagem (entre as margens).
+    assert 400 < chart.points[0].x < 470
+
+
+# --------------------------------------------------------------------------- #
+# Gráfico de uso público (área de série única — requisições/dia)
+# --------------------------------------------------------------------------- #
+def _usage_series(totals: list[int], start: date | None = None) -> list[PublicUsagePoint]:
+    start = start or date(2026, 7, 1)
+    return [PublicUsagePoint(date=start + timedelta(days=i), total=t) for i, t in enumerate(totals)]
+
+
+def test_public_usage_empty_has_no_data():
+    chart = build_public_usage_chart([])
+    assert chart.has_data is False
+    assert chart.points == []
+    assert chart.line == ""
+    assert chart.area == ""
+
+
+def test_public_usage_all_zero_is_empty_but_valid_axes():
+    chart = build_public_usage_chart(_usage_series([0] * 7))
+    assert chart.has_data is False
+    assert len(chart.points) == 7
+    assert chart.max_value >= 4  # eixo utilizável mesmo sem tráfego
+    assert chart.y_ticks
+
+
+def test_public_usage_nice_max_and_paths():
+    chart = build_public_usage_chart(_usage_series([120, 890, 1250]))
+    assert chart.has_data is True
+    assert chart.max_value >= 1250
+    assert len(chart.y_ticks) == 5
+    assert chart.area.startswith("M")
+    assert chart.area.endswith("Z")
+    assert len(chart.line.split(" ")) == 3
+    # O último dia sempre rotulado no eixo X.
+    assert chart.x_ticks[-1].label == "03/07"
+
+
+def test_public_usage_higher_value_maps_higher():
+    chart = build_public_usage_chart(_usage_series([100, 1000]))
+    p_low, p_high = chart.points
+    # y cresce para baixo no SVG: total maior deve ter y MENOR (mais no topo).
+    assert p_high.y < p_low.y
+
+
+def test_public_usage_single_point_centered():
+    chart = build_public_usage_chart(_usage_series([50]))
+    assert len(chart.points) == 1
     assert 400 < chart.points[0].x < 470
 
 

--- a/tests/unit/test_usage_public.py
+++ b/tests/unit/test_usage_public.py
@@ -1,0 +1,73 @@
+"""
+Testes do resumo público de uso (app/services/usage_service.public_usage_summary).
+
+Cobre: resumo vazio (has_data False, séries gap-filled), agregação por janela
+(7/30/90 a partir de uma única varredura), total acumulado, dia de início e KPIs
+de adoção. Nunca expõe taxa de erro (só ``count``).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from app.db.tables import UsageBucket, UsageRecord
+from app.services import usage_service
+from app.services.usage_service import _day_window_start
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed(session, api_key_id: str, days_ago: int, bucket: UsageBucket, count: int) -> None:
+    session.add(
+        UsageRecord(
+            api_key_id=api_key_id,
+            bucket=bucket,
+            window_start=_day_window_start() - timedelta(days=days_ago),
+            count=count,
+        )
+    )
+
+
+async def test_empty_summary(db_session):
+    summary = await usage_service.public_usage_summary(db_session)
+    assert summary.has_data is False
+    assert summary.total_to_date == 0
+    assert summary.period_start is None
+    assert summary.developers == 0
+    assert {w.days for w in summary.windows} == {7, 30, 90}
+    # Séries sempre preenchidas (gap-fill), com tamanho == dias da janela.
+    for w in summary.windows:
+        assert len(w.series) == w.days
+        assert all(p.total == 0 for p in w.series)
+
+
+async def test_windows_slice_from_single_scan(db_session, api_key):
+    _full_key, key = api_key
+    await _seed(db_session, key.id, 0, UsageBucket.deterministic, 100)
+    await _seed(db_session, key.id, 0, UsageBucket.ai, 20)  # mesmo dia, outro bucket
+    await _seed(db_session, key.id, 3, UsageBucket.deterministic, 50)  # dentro de 7d
+    await _seed(db_session, key.id, 20, UsageBucket.deterministic, 200)  # dentro de 30d
+    await _seed(db_session, key.id, 45, UsageBucket.deterministic, 300)  # dentro de 90d
+    await db_session.commit()
+
+    summary = await usage_service.public_usage_summary(db_session)
+    by_days = {w.days: w for w in summary.windows}
+
+    assert by_days[7].total_requests == 170  # 120 + 50
+    assert by_days[30].total_requests == 370  # + 200
+    assert by_days[90].total_requests == 670  # + 300
+
+    assert summary.has_data is True
+    assert summary.total_to_date == 670
+    assert summary.period_start == (_day_window_start() - timedelta(days=45)).date()
+    assert summary.developers == 1
+    assert summary.active_keys == 1
+    # O último ponto de cada série é sempre hoje.
+    for w in summary.windows:
+        assert w.series[-1].date == _day_window_start().date()
+
+
+async def test_default_window_is_valid(db_session):
+    summary = await usage_service.public_usage_summary(db_session)
+    assert summary.default_window in {w.days for w in summary.windows}


### PR DESCRIPTION
## Resumo

Adiciona um gráfico **público** de uso da plataforma (requisições/dia) na landing, unificado com a transparência de custos já existente sob uma seção **"Transparência"**. Uso real em cima, custo real embaixo.

Decisões de produto aprovadas: métricas = **volume + adoção**; local = **na landing junto dos custos**.

## O que muda

- **`usage_service.public_usage_summary`** — agrega toda a plataforma (espelha `public_cost_summary`). Só métricas **agregadas**; **sem taxa de erro** na página pública (recon → fica no `/admin`) e sem custo de IA por request (evita incentivo a cost-amplification).
- **KPIs de adoção**: requisições no total (desde o mês de início), desenvolvedores (contas distintas com ≥1 requisição), chaves ativas.
- **Filtro de janela 7/30/90 dias** pré-renderizado no servidor; alterna só no DOM (`data-window-btn`/`.usage-window`) — **zero requisição/query nova por clique**.
- **`build_public_usage_chart`** — área SSR de série única (sem lib/JS/CDN), tabela a11y de fallback, tokens/temas claro-escuro existentes. Design guiado pelo skill ui-ux-pro-max.
- **Cache TTL de 10 min** em processo cobrindo uso+custos: 1 query por janela independentemente do tráfego, sem depender do CDN frágil (Firebase/Fastly).
- Filtro Jinja **`milhar`** (pt-BR).

## Segurança & custo

- Agregado, nunca por conta/IP/key. Taxa de erro/sucesso jamais exposta publicamente.
- "Live" rotulado com honestidade ("atualizado a cada 10 min"), não tempo real.
- Filtros não geram round-trip; landing pública com custo previsível (Princípio VII).

## Testes

- `tests/unit/test_usage_public.py` — agregação por janela, total acumulado, adoção, resumo vazio.
- `tests/unit/test_charts.py` — geometria do gráfico de uso público.
- `tests/integration/test_landing_transparency.py` — seção aparece com dados, some vazia, resiliente a falha (200 sempre), sem "taxa de sucesso" no HTML público.

Suíte unit + integration + contract (uso/admin) verde. ruff/black/mypy (código novo) limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)