### PR TITLE
Transparência de custos: seed manual, robustez do ingestor e redesign da seção

### DIFF
--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -799,20 +799,66 @@ input[type="password"]::-ms-clear { display: none; }
 .chart-data summary { cursor: pointer; color: var(--fg-muted); font-size: 0.85rem; min-height: 36px; display: inline-flex; align-items: center; }
 .chart-empty { padding: 2.5rem 1rem; text-align: center; }
 
-/* Transparência (uso + custos na landing) */
-.transparency-block + .transparency-block { margin-top: 3rem; }
-.transparency-subtitle { font-size: 1.2rem; font-weight: 700; margin: 0 0 0.35rem; letter-spacing: -0.01em; }
-.transparency-note { margin: 0; max-width: 44rem; }
+/* ---------------------- Transparência (uso + custos) -------------------- */
+.transparency-lead { margin-bottom: 2rem; }
+.transparency-board { display: grid; gap: 1.25rem; }
+
+/* Um painel compacto por domínio: número-herói + estatísticas enxutas + gráfico */
+.transparency-panel {
+  border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-soft); padding: 1.6rem;
+}
+
+.tp-head { display: flex; flex-direction: column; gap: 0.15rem; }
+.tp-overline {
+  margin: 0; font-size: 0.72rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.09em; color: var(--fg-subtle);
+}
+.tp-hero { margin: 0.15rem 0 0; display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+.tp-value {
+  font-size: clamp(1.8rem, 4vw, 2.4rem); font-weight: 700; color: var(--fg);
+  letter-spacing: -0.025em; line-height: 1.05; font-variant-numeric: tabular-nums;
+}
+.tp-unit { font-size: 0.95rem; color: var(--fg-muted); font-weight: 500; }
+.tp-since { margin: 0.3rem 0 0; font-size: 0.85rem; color: var(--fg-muted); }
+
+/* Faixa de estatísticas secundárias — enxuta, sem cartões grandes */
+.tp-stats {
+  display: flex; flex-wrap: wrap; gap: 1.1rem 2rem; margin: 1.2rem 0 0;
+  padding: 1.15rem 0 0; border-top: 1px solid var(--border);
+}
+.tp-stat { display: flex; flex-direction: column; gap: 0.2rem; }
+.tp-stat dt {
+  font-size: 0.8rem; color: var(--fg-muted); font-weight: 500;
+  display: inline-flex; align-items: center; gap: 0.4rem;
+}
+.tp-stat dd {
+  margin: 0; font-size: 1.15rem; font-weight: 700; color: var(--fg);
+  letter-spacing: -0.01em; font-variant-numeric: tabular-nums;
+}
+
+/* Gráfico dentro do painel */
+.tp-chart { margin-top: 1.4rem; }
+.tp-chart-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 0.5rem 1rem; flex-wrap: wrap; margin-bottom: 0.65rem;
+}
+.tp-chart-title { margin: 0; font-weight: 600; font-size: 0.95rem; }
+.tp-chart-caption { margin: 0; font-size: 0.82rem; }
+.tp-chart-foot { margin: 0.55rem 0 0; font-size: 0.85rem; color: var(--fg-muted); }
+.tp-chart-foot strong { color: var(--fg); font-variant-numeric: tabular-nums; }
+.tp-source { margin: 1.2rem 0 0; font-size: 0.8rem; color: var(--fg-muted); }
+.usage-window[hidden] { display: none; }
 
 /* Filtro de janela (pílulas segmentadas) */
 .chart-filters {
-  display: inline-flex; gap: 0.25rem; padding: 0.25rem;
+  display: inline-flex; gap: 0.2rem; padding: 0.2rem;
   background: var(--bg-sunken); border-radius: 999px;
 }
 .chart-filter {
   border: 0; background: transparent; color: var(--fg-muted);
-  font: inherit; font-size: 0.82rem; font-weight: 600;
-  padding: 0.4rem 0.85rem; min-height: 40px; border-radius: 999px;
+  font: inherit; font-size: 0.8rem; font-weight: 600;
+  padding: 0.4rem 0.8rem; min-height: 40px; border-radius: 999px;
   cursor: pointer; white-space: nowrap;
   transition: background 0.15s ease, color 0.15s ease;
 }
@@ -821,24 +867,25 @@ input[type="password"]::-ms-clear { display: none; }
   background: var(--bg); color: var(--brand); box-shadow: var(--shadow-sm);
 }
 .chart-filter:focus-visible { outline: 3px solid var(--brand); outline-offset: 2px; }
-@media (prefers-reduced-motion: reduce) { .chart-filter { transition: none; } }
 
-.usage-kpis { margin-top: 1.25rem; margin-bottom: 1.5rem; }
-.usage-window-total { margin: 0.85rem 0 0; font-size: 0.9rem; }
-.usage-window-total strong { color: var(--fg); font-variant-numeric: tabular-nums; }
-.usage-window[hidden] { display: none; }
-
-/* Custo por serviço (transparência de custos na landing) */
-.cost-kpis { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+/* Custo por serviço */
 .cost-chart .cost-bar { stroke: var(--bg); stroke-width: 1; transition: opacity 0.15s ease; }
 .cost-chart .cost-bar:hover { opacity: 0.82; }
 rect.cost-seg-banco, .dot.cost-seg-banco { fill: var(--cost-banco); background: var(--cost-banco); }
 rect.cost-seg-servidor, .dot.cost-seg-servidor { fill: var(--cost-servidor); background: var(--cost-servidor); }
 rect.cost-seg-ia, .dot.cost-seg-ia { fill: var(--cost-ia); background: var(--cost-ia); }
 rect.cost-seg-outros, .dot.cost-seg-outros { fill: var(--cost-outros); background: var(--cost-outros); }
-.cost-legend { flex-wrap: wrap; }
-.cost-note { margin-top: 1rem; font-size: 0.85rem; }
-@media (prefers-reduced-motion: reduce) { .cost-chart .cost-bar { transition: none; } }
+
+/* Painéis empilhados e full-width: mantém os rótulos dos eixos legíveis (as
+   séries vêm em SVG 840x260 do servidor; em coluna dupla o texto ficaria pequeno
+   demais). A compactação vem do painel enxuto, não de espremer o gráfico. */
+@media (max-width: 40rem) {
+  .transparency-panel { padding: 1.2rem; }
+  .tp-stats { gap: 1rem 1.5rem; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chart-filter, .cost-chart .cost-bar { transition: none; }
+}
 
 /* KPIs */
 .kpi-grid { grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr)); margin-top: 1.25rem; }

--- a/app/web/templates/landing.html
+++ b/app/web/templates/landing.html
@@ -368,54 +368,54 @@ API keys self-service.{% endblock %}
 {% if (usage_summary and usage_summary.has_data) or (cost_chart and cost_chart.has_data) %}
 <section class="section container" id="transparencia" aria-labelledby="transparencia-title">
   <h2 id="transparencia-title">Transparência</h2>
-  <p class="lead">
-    Código aberto não para no repositório. Aqui ficam o uso real da plataforma e a conta
-    que ela gera — números agregados, sem login, atualizados a cada 10 minutos.
+  <p class="lead transparency-lead">
+    O uso real da plataforma e quanto custa mantê-la no ar. Números agregados,
+    sem login, atualizados a cada 10 minutos.
   </p>
 
+  <div class="transparency-board">
+
   {% if usage_summary and usage_summary.has_data %}
-  <div class="transparency-block usage-block">
-    <h3 class="transparency-subtitle">Uso da plataforma</h3>
-    <p class="muted transparency-note">
-      Requisições atendidas, dia a dia. Só o total agregado — nada por usuário, chave ou IP.
-    </p>
+    <article class="transparency-panel usage-block">
+      <header class="tp-head">
+        <p class="tp-overline">Uso da plataforma</p>
+        <p class="tp-hero">
+          <span class="tp-value">{{ usage_summary.total_to_date|milhar }}</span>
+          <span class="tp-unit">requisições atendidas</span>
+        </p>
+        <p class="tp-since">
+          {% if usage_summary.period_start %}desde {{ usage_summary.period_start.strftime('%m/%Y') }} · {% endif %}só o total — nada por usuário, chave ou IP
+        </p>
+      </header>
 
-    <div class="grid kpi-grid usage-kpis">
-      <div class="kpi">
-        <p class="kpi-label">Requisições no total{% if usage_summary.period_start %} · desde {{ usage_summary.period_start.strftime('%m/%Y') }}{% endif %}</p>
-        <p class="kpi-value">{{ usage_summary.total_to_date|milhar }}</p>
-      </div>
-      <div class="kpi">
-        <p class="kpi-label">Desenvolvedores</p>
-        <p class="kpi-value">{{ usage_summary.developers|milhar }}</p>
-      </div>
-      <div class="kpi">
-        <p class="kpi-label">Chaves ativas</p>
-        <p class="kpi-value">{{ usage_summary.active_keys|milhar }}</p>
-      </div>
-    </div>
-
-    <div class="card chart-card usage-card">
-      <div class="chart-head">
-        <div>
-          <p class="chart-title">Requisições por dia</p>
-          <p class="chart-caption muted">Toda a plataforma, agregado</p>
+      <dl class="tp-stats">
+        <div class="tp-stat">
+          <dt>Desenvolvedores</dt>
+          <dd>{{ usage_summary.developers|milhar }}</dd>
         </div>
-        <div class="chart-filters" role="group" aria-label="Período do gráfico">
-          {% for w in usage_summary.windows %}
-          <button type="button" class="chart-filter{% if w.days == usage_summary.default_window %} is-active{% endif %}"
-                  data-window-btn="{{ w.days }}"
-                  aria-pressed="{{ 'true' if w.days == usage_summary.default_window else 'false' }}">
-            {{ w.days }} dias
-          </button>
-          {% endfor %}
+        <div class="tp-stat">
+          <dt>Chaves ativas</dt>
+          <dd>{{ usage_summary.active_keys|milhar }}</dd>
         </div>
-      </div>
+      </dl>
 
-      {% for w in usage_summary.windows %}
-      {% set chart = usage_charts[w.days] %}
-      <div class="usage-window" data-window="{{ w.days }}"{% if w.days != usage_summary.default_window %} hidden{% endif %}>
-        <div class="chart-wrap">
+      <div class="tp-chart">
+        <div class="tp-chart-head">
+          <p class="tp-chart-title">Requisições por dia</p>
+          <div class="chart-filters" role="group" aria-label="Período do gráfico">
+            {% for w in usage_summary.windows %}
+            <button type="button" class="chart-filter{% if w.days == usage_summary.default_window %} is-active{% endif %}"
+                    data-window-btn="{{ w.days }}"
+                    aria-pressed="{{ 'true' if w.days == usage_summary.default_window else 'false' }}">
+              {{ w.days }}d
+            </button>
+            {% endfor %}
+          </div>
+        </div>
+
+        {% for w in usage_summary.windows %}
+        {% set chart = usage_charts[w.days] %}
+        <div class="usage-window" data-window="{{ w.days }}"{% if w.days != usage_summary.default_window %} hidden{% endif %}>
           <svg class="usage-chart" viewBox="0 0 {{ chart.width }} {{ chart.height }}"
                role="img" preserveAspectRatio="none"
                aria-label="Requisições por dia nos últimos {{ w.days }} dias. Total de {{ w.total_requests|milhar }} requisições, média de {{ w.daily_average|milhar }} por dia.">
@@ -429,118 +429,103 @@ API keys self-service.{% endblock %}
             <text class="chart-axis" x="{{ t.pos }}" y="{{ chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
             {% endfor %}
           </svg>
+          <p class="tp-chart-foot">
+            <strong>{{ w.total_requests|milhar }}</strong> em {{ w.days }} dias · <strong>{{ w.daily_average|milhar }}</strong>/dia em média
+          </p>
         </div>
-        <p class="usage-window-total muted">
-          <strong>{{ w.total_requests|milhar }}</strong> requisições em {{ w.days }} dias ·
-          média de <strong>{{ w.daily_average|milhar }}</strong>/dia
-        </p>
-      </div>
-      {% endfor %}
+        {% endfor %}
 
-      {% set dw = usage_summary.windows | selectattr('days', 'equalto', usage_summary.default_window) | first %}
-      {% if dw %}
-      <details class="chart-data">
-        <summary>Ver dados em tabela ({{ dw.days }} dias)</summary>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th scope="col">Dia</th><th scope="col">Requisições</th></tr></thead>
-            <tbody>
-              {% for p in dw.series %}
-              <tr><td data-label="Dia">{{ p.date.strftime('%d/%m') }}</td><td data-label="Requisições">{{ p.total|milhar }}</td></tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </details>
-    {% endif %}
-    </div>
-  </div>
+        {% set dw = usage_summary.windows | selectattr('days', 'equalto', usage_summary.default_window) | first %}
+        {% if dw %}
+        <details class="chart-data">
+          <summary>Ver dados em tabela ({{ dw.days }} dias)</summary>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th scope="col">Dia</th><th scope="col">Requisições</th></tr></thead>
+              <tbody>
+                {% for p in dw.series %}
+                <tr><td data-label="Dia">{{ p.date.strftime('%d/%m') }}</td><td data-label="Requisições">{{ p.total|milhar }}</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </details>
+        {% endif %}
+      </div>
+    </article>
   {% endif %}
 
   {% if cost_chart and cost_chart.has_data %}
-  <div class="transparency-block cost-block">
-    <h3 class="transparency-subtitle">Transparência de custos</h3>
-    <p class="muted transparency-note">
-      Quanto custa manter a BNCC API no ar. Valores reais faturados pelo Google Cloud,
-      por mês e por serviço.
-    </p>
+    <article class="transparency-panel cost-block">
+      <header class="tp-head">
+        <p class="tp-overline">Custo de infraestrutura</p>
+        <p class="tp-hero">
+          <span class="tp-value">{{ cost_summary.total_to_date|brl }}</span>
+          <span class="tp-unit">até agora</span>
+        </p>
+        <p class="tp-since">
+          {% if cost_summary and cost_summary.period_start %}desde {{ cost_summary.period_start.strftime('%m/%Y') }} · {% endif %}{{ cost_summary.total_month|brl }} neste mês
+        </p>
+      </header>
 
-    <div class="grid kpi-grid cost-kpis">
-      <div class="kpi">
-        <p class="kpi-label">Total até agora{% if cost_summary and cost_summary.period_start %} · desde {{ cost_summary.period_start.strftime('%m/%Y') }}{% endif %}</p>
-        <p class="kpi-value">{{ cost_summary.total_to_date|brl }}</p>
-      </div>
-      <div class="kpi">
-        <p class="kpi-label">Mês atual</p>
-        <p class="kpi-value">{{ cost_summary.total_month|brl }}</p>
-      </div>
-      {% for item in cost_summary.by_service_to_date %}
-      {% if item.amount > 0 %}
-      <div class="kpi">
-        <p class="kpi-label"><span class="dot cost-seg-{{ item.service.value }}"></span>{{ item.label }}</p>
-        <p class="kpi-value">{{ item.amount|brl }}</p>
-      </div>
-      {% endif %}
-      {% endfor %}
-    </div>
-
-    <div class="card chart-card">
-      <div class="chart-head">
-        <div>
-          <p class="chart-title">Custo mensal de infraestrutura</p>
-          <p class="chart-caption muted">Por serviço, em reais (R$)</p>
+      <dl class="tp-stats tp-breakdown">
+        {% for item in cost_summary.by_service_to_date %}
+        {% if item.amount > 0 %}
+        <div class="tp-stat">
+          <dt><span class="dot cost-seg-{{ item.service.value }}"></span>{{ item.label }}</dt>
+          <dd>{{ item.amount|brl }}</dd>
         </div>
-        <ul class="chart-legend cost-legend" aria-hidden="true">
-          {% for item in cost_chart.legend %}
-          <li><span class="dot {{ item.color_class }}"></span>{{ item.label }}</li>
-          {% endfor %}
-        </ul>
-      </div>
+        {% endif %}
+        {% endfor %}
+      </dl>
 
-      <div class="chart-wrap">
+      <div class="tp-chart">
+        <div class="tp-chart-head">
+          <p class="tp-chart-title">Custo por mês</p>
+          <p class="tp-chart-caption muted">por serviço, em R$</p>
+        </div>
+
         <svg class="usage-chart cost-chart" viewBox="0 0 {{ cost_chart.width }} {{ cost_chart.height }}"
              role="img" preserveAspectRatio="none"
              aria-label="Custo mensal de infraestrutura por serviço, em reais. Total acumulado de {{ cost_summary.total_to_date|brl }}.">
-          <!-- gridlines + rótulos do eixo Y -->
           {% for t in cost_chart.y_ticks %}
           <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ cost_chart.width - 12 }}" y2="{{ t.pos }}"/>
           <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
           {% endfor %}
-          <!-- barras empilhadas (um segmento por serviço) -->
           {% for bar in cost_chart.bars %}
             {% for seg in bar.segments %}
             <rect class="cost-bar {{ seg.color_class }}" x="{{ seg.x }}" y="{{ seg.y }}"
                   width="{{ seg.width }}" height="{{ seg.height }}"><title>{{ seg.title }}</title></rect>
             {% endfor %}
           {% endfor %}
-          <!-- rótulos do eixo X -->
           {% for t in cost_chart.x_ticks %}
           <text class="chart-axis" x="{{ t.pos }}" y="{{ cost_chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
           {% endfor %}
         </svg>
+
+        <details class="chart-data">
+          <summary>Ver dados em tabela</summary>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th scope="col">Mês</th><th scope="col">Total</th></tr></thead>
+              <tbody>
+                {% for bar in cost_chart.bars %}
+                <tr><td data-label="Mês">{{ bar.label }}</td><td data-label="Total">{{ bar.total|brl }}</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </details>
       </div>
 
-      <details class="chart-data">
-        <summary>Ver dados em tabela</summary>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th scope="col">Mês</th><th scope="col">Total</th></tr></thead>
-            <tbody>
-              {% for bar in cost_chart.bars %}
-              <tr><td data-label="Mês">{{ bar.label }}</td><td data-label="Total">{{ bar.total|brl }}</td></tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </details>
-    </div>
-
-    <p class="notice cost-note">
-      Fonte: faturamento real do Google Cloud (BigQuery billing export), líquido de créditos.
-      É o custo de <strong>infraestrutura</strong> da plataforma — não é dado da BNCC.
-    </p>
-  </div>
+      <p class="tp-source">
+        Faturamento real do Google Cloud, líquido de créditos. Custo de
+        <strong>infraestrutura</strong> — não é dado da BNCC.
+      </p>
+    </article>
   {% endif %}
+
+  </div>
 </section>
 {% endif %}
 

--- a/deploy/cloudrun.ps1
+++ b/deploy/cloudrun.ps1
@@ -54,6 +54,7 @@ param(
   [string]$BillingDataset = "",  # dataset do BigQuery billing export (habilita "Transparencia de custos")
   [string]$BillingTable   = "",  # tabela do export (ex.: gcp_billing_export_v1_XXXXXX_XXXXXX_XXXXXX)
   [string]$CostCron       = "0 6 * * *",  # agendamento do ingestor de custos (cron, UTC)
+  [string]$CostSince      = "",  # fixa o 1o mes que o ingestor le do BigQuery (YYYY-MM); vazio = padrao de ~13 meses. Use quando meses anteriores foram semeados a mao (scripts/seed_cost_history.py) para o job nao sobrescreve-los.
   [switch]$SkipBuild             # reaproveita a imagem ja publicada (nao rebuilda)
 )
 
@@ -301,12 +302,15 @@ if ($BillingDataset -and $BillingTable) {
   $costEnv["GCP_BILLING_TABLE"]   = $BillingTable
   $costVerb = if (Exists { gcloud run jobs describe $costJob --region=$Region }) { "update" } else { "create" }
   $envFileCost = Write-EnvFile $costEnv
+  # Args do ingestor: fixa --since quando $CostSince e informado (nao sobrescreve
+  # meses historicos semeados a mao; ver scripts/seed_cost_history.py).
+  $costArgs = if ($CostSince) { "scripts/ingest_costs.py,--since,$CostSince" } else { "scripts/ingest_costs.py" }
   Exec { gcloud run jobs $costVerb $costJob `
     --image=$ImageUri --region=$Region `
     --set-cloudsql-instances=$Csql `
     --env-vars-file=$envFileCost `
     --set-secrets="$commonSecrets" `
-    --command="python" --args="scripts/ingest_costs.py" }
+    --command="python" --args="$costArgs" }
   Remove-Item $envFileCost -Force
   # Execucao inicial (semeia os dados; sem export ainda, sai 0 sem gravar).
   Exec { gcloud run jobs execute $costJob --region=$Region --wait }

--- a/scripts/ingest_costs.py
+++ b/scripts/ingest_costs.py
@@ -199,8 +199,16 @@ async def _run(since_ym: str, dry_run: bool) -> int:
 
     agg = aggregate_rows(rows, rate=settings.USD_BRL_RATE)
     if not agg:
-        logger.warning("Nenhuma linha de custo retornada (since=%s).", since_ym)
-        return 0
+        # Zero linhas é anômalo para um projeto com gasto: sinaliza export de billing
+        # não habilitado/atrasado ou tabela errada. Retorna != 0 para o Cloud Scheduler
+        # acusar falha (alerta), em vez de "sucesso" mascarar a landing vazia por dias.
+        logger.error(
+            "Nenhuma linha de custo retornada (since=%s). Verifique se o BigQuery billing "
+            "export está habilitado e populado para %s.",
+            since_ym,
+            since_ym,
+        )
+        return 5
 
     for (month, service), amount in sorted(agg.items()):
         logger.info("%s  %-9s  R$ %s", month.isoformat(), service.value, amount.quantize(_CENTS))

--- a/scripts/seed_cost_history.py
+++ b/scripts/seed_cost_history.py
@@ -1,0 +1,254 @@
+"""
+Semeadura manual do histórico de custos em ``cost_records`` a partir do CSV do
+relatório de Faturamento do GCP (console → Billing → Reports → "Baixar o CSV").
+
+Motivo (fidelidade + Princípio VII): o BigQuery billing export **não faz backfill**
+— só entrega dados a partir da data em que foi habilitado. Os meses anteriores só
+existem no relatório de Faturamento do console. Como a landing lê apenas
+``cost_records`` (nunca o BigQuery em runtime), este utilitário permite semear esses
+meses históricos com ``source="manual"``, distinguindo-os claramente da ingestão
+automática (``source="bigquery"``), sem violar a fronteira de dados.
+
+Espelha ``scripts/ingest_costs.py``: mesma classificação de serviço em buckets
+(``bucket_service``), mesmo grão ``(period_month, service)``, mesmo upsert idempotente
+— só muda a origem (CSV do console em vez do BigQuery) e o ``source``.
+
+CADA CSV cobre UM mês. O mês é inferido do nome do arquivo (padrão do console
+``... 2026-07-01 — 2026-07-31.csv``) ou informado com ``--month YYYY-MM``.
+
+Uso:
+    python scripts/seed_cost_history.py "reports_2026-06.csv"          # 1 mês (do nome)
+    python scripts/seed_cost_history.py *.csv                          # vários meses
+    python scripts/seed_cost_history.py julho.csv --month 2026-07      # mês explícito
+    python scripts/seed_cost_history.py "reports_2026-06.csv" --dry-run
+
+Para semear PRODUÇÃO, aponte ``DATABASE_URL`` para o Cloud SQL (via Cloud SQL Auth
+Proxy) antes de rodar — o script grava no banco de ``app.db.base``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import io
+import logging
+import re
+import sys
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+# Raiz do projeto no sys.path.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("seed_cost_history")
+
+from app.db.tables import CostService  # noqa: E402  (após ajuste do sys.path)
+
+from scripts.ingest_costs import _CENTS, bucket_service  # noqa: E402  (reuso da classificação)
+
+# Mês no nome do arquivo: "...YYYY-MM-DD — ...csv" (padrão do console) ou "...YYYY-MM...".
+_MONTH_IN_NAME = re.compile(r"(\d{4})-(\d{2})(?:-\d{2})?")
+
+
+# --------------------------------------------------------------------------- #
+# Parsing puro (testável sem banco)
+# --------------------------------------------------------------------------- #
+def parse_brl(value: str) -> Decimal:
+    """Converte um número no formato pt-BR do CSV ('1.234,56', '- 30,73', '—') em Decimal.
+
+    ``.`` é separador de milhar e ``,`` é decimal. Traço/em-dash e vazio viram 0.
+    """
+    s = (value or "").strip().replace("R$", "").replace("—", "").replace(" ", "")
+    if not s or s == "-":
+        return Decimal("0")
+    s = s.replace(".", "").replace(",", ".")
+    try:
+        return Decimal(s)
+    except InvalidOperation:
+        logger.warning("Valor não numérico ignorado: %r", value)
+        return Decimal("0")
+
+
+def month_from_filename(name: str) -> date | None:
+    """Extrai o 1º dia do mês do nome do arquivo do console (1ª data encontrada)."""
+    m = _MONTH_IN_NAME.search(name)
+    if not m:
+        return None
+    return date(int(m.group(1)), int(m.group(2)), 1)
+
+
+def _find_column(header: list[str], *needles: str) -> int:
+    """Índice da 1ª coluna cujo cabeçalho contém um dos ``needles`` (case-insensitive)."""
+    low = [h.strip().lower().lstrip("﻿") for h in header]
+    for needle in needles:
+        for i, h in enumerate(low):
+            if needle in h:
+                return i
+    return -1
+
+
+def aggregate_csv(text: str) -> dict[CostService, Decimal]:
+    """Agrega o CSV de um mês (por serviço) em custo líquido por bucket, em BRL.
+
+    Usa a coluna "Subtotal não arredondado" (custo líquido = custo + economias, já
+    aplicadas as economias), mantendo precisão total — o arredondamento a centavos
+    acontece só na gravação, como no ingestor. Linhas de rodapé (Subtotal/Tributo/
+    Total filtrado, sem descrição de serviço) são ignoradas.
+    """
+    rows = list(csv.reader(io.StringIO(text)))
+    if not rows:
+        return {}
+    header = rows[0]
+    svc_i = _find_column(header, "descrição do serviço", "serviço", "service")
+    net_i = _find_column(header, "arredondado", "subtotal")
+    if svc_i < 0 or net_i < 0:
+        raise ValueError(
+            "CSV não reconhecido: faltam colunas de serviço e/ou subtotal "
+            f"(cabeçalho: {header!r})"
+        )
+
+    agg: dict[CostService, Decimal] = {}
+    for row in rows[1:]:
+        if len(row) <= max(svc_i, net_i):
+            continue
+        service_desc = row[svc_i].strip()
+        if not service_desc:  # rodapé (Subtotal/Tributo/Total filtrado)
+            continue
+        bucket = bucket_service(service_desc)
+        agg[bucket] = agg.get(bucket, Decimal("0")) + parse_brl(row[net_i])
+    return agg
+
+
+# --------------------------------------------------------------------------- #
+# Persistência (upsert idempotente — padrão de ingest_costs._upsert, source=manual)
+# --------------------------------------------------------------------------- #
+async def _upsert(session, month: date, service: CostService, amount: Decimal, source: str) -> None:
+    from app.db.tables import CostRecord
+    from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
+
+    dt = datetime(month.year, month.month, month.day, tzinfo=UTC)
+    value = amount.quantize(_CENTS)
+
+    def _query():
+        return select(CostRecord).where(
+            CostRecord.period_month == dt, CostRecord.service == service
+        )
+
+    record = (await session.execute(_query())).scalar_one_or_none()
+    if record is None:
+        record = CostRecord(
+            period_month=dt, service=service, amount=value, currency="BRL", source=source
+        )
+        session.add(record)
+        try:
+            await session.commit()
+            return
+        except IntegrityError:
+            await session.rollback()
+            record = (await session.execute(_query())).scalar_one()
+
+    record.amount = value
+    record.currency = "BRL"
+    record.source = source
+    await session.commit()
+
+
+async def _persist(months: dict[date, dict[CostService, Decimal]], source: str) -> int:
+    from app.db.base import async_session_factory
+
+    written = 0
+    async with async_session_factory() as session:
+        for month in sorted(months):
+            for service, amount in sorted(months[month].items(), key=lambda kv: kv[0].value):
+                if amount.quantize(_CENTS) == Decimal("0.00"):
+                    continue  # não polui o breakdown com buckets zerados
+                await _upsert(session, month, service, amount, source)
+                written += 1
+    return written
+
+
+# --------------------------------------------------------------------------- #
+# Orquestração
+# --------------------------------------------------------------------------- #
+def _resolve_month(path: Path, override: date | None) -> date:
+    if override is not None:
+        return override
+    month = month_from_filename(path.name)
+    if month is None:
+        raise SystemExit(
+            f"Não consegui inferir o mês de {path.name!r}. "
+            "Renomeie no padrão do console (…YYYY-MM-DD — …) ou passe --month YYYY-MM."
+        )
+    return month
+
+
+async def _run(paths: list[Path], override: date | None, source: str, dry_run: bool) -> int:
+    months: dict[date, dict[CostService, Decimal]] = {}
+    if override is not None and len(paths) > 1:
+        raise SystemExit("--month só é válido com um único CSV (cada arquivo é um mês).")
+
+    for path in paths:
+        if not path.exists():
+            raise SystemExit(f"Arquivo não encontrado: {path}")
+        month = _resolve_month(path, override)
+        agg = aggregate_csv(path.read_text(encoding="utf-8-sig"))
+        if not agg:
+            logger.warning("%s: nenhuma linha de serviço reconhecida.", path.name)
+            continue
+        # Se dois CSVs cairem no mesmo mês, soma (não deveria acontecer no fluxo normal).
+        bucket = months.setdefault(month, {})
+        total = Decimal("0")
+        for service, amount in agg.items():
+            bucket[service] = bucket.get(service, Decimal("0")) + amount
+            total += amount
+        logger.info(
+            "%s  total R$ %s  (%s)",
+            month.isoformat(),
+            total.quantize(_CENTS),
+            ", ".join(
+                f"{s.value}={a.quantize(_CENTS)}"
+                for s, a in sorted(agg.items(), key=lambda kv: kv[0].value)
+            ),
+        )
+
+    if not months:
+        logger.warning("Nada a gravar.")
+        return 0
+
+    if dry_run:
+        logger.info("[dry-run] %d mês(es) agregado(s) — nada gravado.", len(months))
+        return 0
+
+    written = await _persist(months, source)
+    logger.info("Gravadas %d linhas em cost_records (source=%s).", written, source)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Semeia o histórico de custos em cost_records a partir do CSV do console GCP."
+    )
+    parser.add_argument("csv", nargs="+", help="Um ou mais CSVs do relatório de Faturamento.")
+    parser.add_argument("--month", help="Mês YYYY-MM (só com um CSV; sobrepõe o nome do arquivo).")
+    parser.add_argument(
+        "--source", default="manual", help="Valor do campo source (padrão 'manual')."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Só agrega e imprime; não grava.")
+    args = parser.parse_args()
+
+    override: date | None = None
+    if args.month:
+        y, m = args.month.split("-")
+        override = date(int(y), int(m), 1)
+
+    paths = [Path(p) for p in args.csv]
+    return asyncio.run(_run(paths, override, args.source, args.dry_run))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_landing_costs.py
+++ b/tests/integration/test_landing_costs.py
@@ -47,7 +47,7 @@ async def test_landing_shows_cost_section_when_seeded(async_client):
     assert resp.status_code == 200
     body = resp.text
     assert 'id="transparencia"' in body
-    assert "Transparência de custos" in body
+    assert "Custo de infraestrutura" in body
     # Total acumulado formatado em BRL (52,30 + 90,00).
     assert "R$ 142,30" in body
 

--- a/tests/unit/test_ingest_costs.py
+++ b/tests/unit/test_ingest_costs.py
@@ -8,10 +8,12 @@ na coluna ``net``). Não toca o BigQuery — linhas são dicts fake.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import date
 from decimal import Decimal
 
 from app.db.tables import CostService
+from scripts import ingest_costs
 from scripts.ingest_costs import aggregate_rows, bucket_service
 
 
@@ -55,3 +57,12 @@ def test_aggregate_rows_keeps_net_credits_even_negative():
     rows = [{"ym": "202607", "svc": "Cloud SQL", "currency": "BRL", "net": "-3.50"}]
     agg = aggregate_rows(rows)
     assert agg[(date(2026, 7, 1), CostService.banco)] == Decimal("-3.50")
+
+
+def test_run_returns_error_when_bigquery_empty(monkeypatch):
+    # Regressão: BigQuery sem linhas (export não habilitado/atrasado) deve retornar
+    # código != 0 para o Scheduler alertar — não mascarar como sucesso.
+    monkeypatch.setattr(ingest_costs, "_config_ok", lambda: True)
+    monkeypatch.setattr(ingest_costs, "_fetch_rows", lambda since: [])
+    code = asyncio.run(ingest_costs._run("202601", dry_run=False))
+    assert code == 5

--- a/tests/unit/test_seed_cost_history.py
+++ b/tests/unit/test_seed_cost_history.py
@@ -1,0 +1,69 @@
+"""
+Testes das funções puras do semeador de histórico de custos
+(scripts/seed_cost_history.py).
+
+Cobre o parsing de números pt-BR, a inferência do mês pelo nome do arquivo e a
+agregação do CSV do console (por serviço → bucket, custo líquido, rodapé ignorado).
+Não toca o banco — usa o texto do CSV diretamente.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.db.tables import CostService
+from scripts.seed_cost_history import aggregate_csv, month_from_filename, parse_brl
+
+# Cabeçalho + linhas reais exportadas pelo console (Billing → Reports → Baixar CSV).
+_CSV = (
+    "Descrição do serviço,ID do serviço,Custo (R$),Programas de economia (R$),"
+    "Outras economias (R$),Subtotal não arredondado (R$),Subtotal (R$),"
+    "Mudança percentual no subtotal em comparação ao período anterior\n"
+    'Cloud Run,152E-C115-5142,"91,14","0,00","- 30,73","60,416712","60,42",Novo\n'
+    'Cloud SQL,9662-B51E-5089,"22,44","0,00","0,00","22,440751","22,44",Novo\n'
+    'Cloud Build,8B5D-EF7D-EB12,"16,39","0,00","0,00","16,385511","16,39",Novo\n'
+    'Artifact Registry,149C-F9EC-3994,"3,98","0,00","0,00","3,978499","3,98",Novo\n'
+    'Gemini API,AEFD-7695-64FA,"0,55","0,00","0,00","0,545759","0,55",Novo\n'
+    'Cloud Storage,95FF-2EF5-5EA1,"0,00","0,00","0,00","0,002970","0,00",Novo\n'
+    ',,,,Subtotal,"103,770202","103,77"\n'
+    ',,,,Tributo,"0,000000","0,00"\n'
+    ',,,,Total filtrado,"103,770202","103,77"\n'
+)
+
+
+def test_parse_brl_formats():
+    assert parse_brl("60,42") == Decimal("60.42")
+    assert parse_brl("- 30,73") == Decimal("-30.73")
+    assert parse_brl("1.234,56") == Decimal("1234.56")
+    assert parse_brl("60,416712") == Decimal("60.416712")
+    assert parse_brl("—") == Decimal("0")
+    assert parse_brl("") == Decimal("0")
+
+
+def test_month_from_filename():
+    assert month_from_filename("🐞 [DEV]_Relatórios, 2026-07-01 — 2026-07-31.csv") == date(
+        2026, 7, 1
+    )
+    assert month_from_filename("reports_2026-05.csv") == date(2026, 5, 1)
+    assert month_from_filename("sem_data.csv") is None
+
+
+def test_aggregate_csv_buckets_and_net():
+    agg = aggregate_csv(_CSV)
+    # Cloud Run → servidor (usa o subtotal não arredondado, líquido de economias).
+    assert agg[CostService.servidor].quantize(Decimal("0.01")) == Decimal("60.42")
+    # Cloud SQL → banco.
+    assert agg[CostService.banco].quantize(Decimal("0.01")) == Decimal("22.44")
+    # Gemini API → ia.
+    assert agg[CostService.ia].quantize(Decimal("0.01")) == Decimal("0.55")
+    # Cloud Build + Artifact Registry + Cloud Storage → outros (catch-all).
+    assert agg[CostService.outros].quantize(Decimal("0.01")) == Decimal("20.37")
+
+
+def test_aggregate_csv_ignores_footer_rows():
+    # As linhas Subtotal/Tributo/Total filtrado (sem serviço) não viram buckets extras
+    # nem inflam os totais — a soma dos buckets casa com o subtotal do relatório.
+    agg = aggregate_csv(_CSV)
+    total = sum(agg.values())
+    assert total.quantize(Decimal("0.000001")) == Decimal("103.770202")


### PR DESCRIPTION
## Contexto
A seção **Transparência de custos** da landing estava vazia: o BigQuery billing export foi habilitado em 10/07 mas ainda não entrega dados (tabela com 0 linhas, apesar de gasto real). O job de ingestão rodava, encontrava 0 linhas e saía com sucesso — mascarando o problema.

## O que este PR faz

### 1. Semeadura manual do histórico (`scripts/seed_cost_history.py`)
Popula `cost_records` a partir do CSV do relatório de Faturamento do console (`source="manual"`), para meses que o export não cobre (o GCP não faz backfill). Reaproveita `bucket_service()` e o upsert idempotente do ingestor; mês inferido do nome do arquivo ou `--month`. A landing continua lendo só o banco (Princípio VII).

### 2. Robustez do ingestor (`scripts/ingest_costs.py`)
BigQuery sem linhas agora retorna **código 5** (era 0) e loga em nível `error` — o Cloud Scheduler passa a acusar falha em vez de esconder a landing vazia.

### 3. `deploy/cloudrun.ps1`
Novo parâmetro `$CostSince` fixa o `--since` do Job de ingestão, evitando sobrescrever meses semeados à mão. (Job de prod já ajustado para `--since 2026-08`.)

### 4. Redesign da seção Transparência (`landing.html` + `styles.css`)
Mais compacta e enxuta: dois painéis (uso/custo) com um número-herói, faixa fina de estatísticas e o gráfico. No custo, o detalhamento por serviço vira a própria legenda (rótulo + valor), eliminando 4 cartões. Copy revista para clareza. Segue o design system existente; hooks de JS e cores por serviço preservados.

## Estado de produção
- `cost_records` **já semeado** (jul/2026, R$ 103,78); landing renderiza a seção (origin + `bncc.api.br`, CDN purgado).

## Testes
- Novos: parsing pt-BR, inferência de mês, agregação/rodapé do CSV; regressão do código de saída para export vazio.
- Landing (uso + custo): 6/6 verdes; asserção ajustada ao novo título do painel.
- ruff / black limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)