### PR TITLE
chore(deps): grupo minor/patch com teto em google-cloud-bigquery 3.30.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,12 @@ updates:
     ignore:
       - dependency-name: "langchain"
       - dependency-name: "langchain-community"
+      # google-cloud-bigquery >=3.31 exige packaging>=24.2, mas langchain-core
+      # 0.1.x (arrastado por langchain==0.1.0) pina packaging<24 — o pip não
+      # resolve (visto no PR #29). Destravado só com o upgrade coordenado do
+      # ecossistema LangChain acima.
+      - dependency-name: "google-cloud-bigquery"
+        versions: [">3.30.0"]
     groups:
       # Agrupa patch/minor de todas as libs num só PR para reduzir ruído.
       python-minor-e-patch:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # --- Lint / Format (espelha o gate de CI; versões idênticas) ---------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.15.21
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 # Web framework / API
 fastapi==0.139.0  # >=0.115.3 corrige CVE-2024-47874; >=0.130 exige starlette/pydantic abaixo
-uvicorn[standard]==0.50.2
+uvicorn[standard]==0.51.0
 starlette==1.3.1  # >=1.0.1 corrige CVE-2026-48710 (BadHost: bypass de auth via Host header); pin explícito
 pydantic==2.13.4  # exigido por fastapi>=0.130 (>=2.9.0)
 pydantic-settings==2.14.2  # acompanha o bump de pydantic (exige pydantic>=2.7.0)
@@ -38,7 +38,10 @@ slowapi==0.1.10
 # ingestão `scripts/ingest_costs.py`; import lazy, o app web nunca o carrega).
 # Cliente CORE (sem extras pandas/bqstorage) → não puxa numpy>=2 (mantém o pino
 # numpy<2 exigido por langchain 0.1.0).
-google-cloud-bigquery==3.27.0
+# TETO 3.30.0: >=3.31 exige packaging>=24.2, mas langchain-core 0.1.x (arrastado
+# por langchain==0.1.0) pina packaging<24 → ResolutionImpossible no pip. Subir
+# além exige upgrade coordenado do ecossistema LangChain (ignore no dependabot.yml).
+google-cloud-bigquery==3.30.0
 
 # Superfícies visuais (SSR: landing + portal + docs)
 Jinja2==3.1.6
@@ -48,7 +51,7 @@ chromadb==1.5.9
 langchain==0.1.0
 langchain-community==0.0.10  # travado por langchain==0.1.0 (exige >=0.0.9,<0.1); Dependabot ignora este pacote
 sentence-transformers==5.6.0  # 2.2.2 quebra com huggingface_hub>=0.26 (cached_download removido)
-openai==2.44.0
+openai==2.45.0
 google-generativeai==0.8.6
 
 # Processamento de dados / extração determinística de PDF
@@ -60,7 +63,7 @@ lxml==6.1.1
 pdfplumber==0.11.10
 PyPDF2==3.0.1
 pypdf==6.14.2
-pikepdf==10.9.1
+pikepdf==10.10.0
 
 # Testes + cobertura (gate de CI ≥ 80%)
 pytest==9.1.1
@@ -69,9 +72,9 @@ pytest-asyncio==1.4.0  # >=1.0 exigido por pytest 9 (0.21 quebra na coleta: Fixt
 # httpx é dependência de runtime (login social) — declarado na seção de segurança acima.
 
 # Qualidade de código
-ruff==0.15.20
+ruff==0.15.21
 black==26.5.1
-mypy==2.1.0
+mypy==2.2.0
 pre-commit==4.6.0
 
 # Documentação


### PR DESCRIPTION
Substitui o PR #29 do Dependabot, que falhava no CI com `ResolutionImpossible`: `google-cloud-bigquery>=3.31` exige `packaging>=24.2`, mas `langchain-core 0.1.x` (arrastado por `langchain==0.1.0`) pina `packaging<24`.

## Bumps
- uvicorn 0.50.2 → 0.51.0
- google-cloud-bigquery 3.27.0 → **3.30.0** (teto; 3.42.2 é irresolvível — comentário no requirements)
- openai 2.44.0 → 2.45.0
- pikepdf 10.9.1 → 10.10.0
- ruff 0.15.20 → 0.15.21 (rev do `.pre-commit-config.yaml` sincronizada, local == CI)
- mypy 2.1.0 → 2.2.0 (gate bloqueante do CI rodado localmente: limpo)

## Guarda-corpo
`dependabot.yml` agora ignora `google-cloud-bigquery >3.30.0` para o PR quebrado não renascer semanalmente; destrava junto com o upgrade coordenado do ecossistema LangChain (mesmo racional do ignore existente).

## Verificação
- `pip install --dry-run` local resolve: `packaging-23.2` + `google-cloud-bigquery-3.30.0` + `langchain-core-0.1.23` ✔
- Conformidade com a Constituição: sem mudança de contrato público (Princípio I); portões de CI seguem bloqueantes (Princípio III).

Fecha #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)