### PR TITLE
Redesenha a landing e os tokens do design system

### DIFF
--- a/.claude/skills/copywriting/SKILL.md
+++ b/.claude/skills/copywriting/SKILL.md
@@ -80,6 +80,70 @@ Each section should advance one argument. Build a logical flow down the page.
 - Passive voice constructions?
 - Exclamation points? (remove them)
 - Marketing buzzwords without substance?
+- AI tells? (run the sweep below — always, on every draft)
+
+---
+
+## Avoiding AI Tells
+
+Readers have learned to recognize machine-generated copy, and it destroys trust instantly.
+These rules are **mandatory on every draft**. One instance of any pattern is fine — the tell is
+density and regularity. **For the full catalog with word lists and the final sweep checklist**:
+See [references/ai-writing-signs.md](references/ai-writing-signs.md).
+
+### Banned constructions
+
+1. **Negative parallelisms** — "It's not just X, it's Y," "not only... but also," "It's not
+   about X; it's about Y," "No X, no Y, just Z." State Y directly instead.
+   - AI: "It's not just a dashboard — it's a command center."
+   - Human: "See every deployment, alert, and rollback in one screen."
+2. **The rule of three everywhere** — "faster, simpler, smarter"; three adjectives, three
+   bullets, three of everything. Max one deliberate triad per page; vary list lengths.
+3. **Superficial "-ing" tails** — "...ensuring your team stays aligned," "...empowering users,"
+   "...highlighting our commitment to quality." Cut the clause or make the claim concrete.
+4. **Copula avoidance** — "serves as," "stands as," "represents," "boasts," "features" instead
+   of plain "is" and "has." "The platform serves as a comprehensive solution" → "The platform is..."
+5. **Significance inflation** — "plays a pivotal role," "is a testament to," "marks a turning
+   point," "cementing its position as." Replace every importance claim with the fact that proves it.
+6. **Vague attribution** — "experts agree," "studies show," "industry leaders trust us." Name
+   the source, number, and date — or delete.
+7. **Didactic filler** — "It's important to note," "It's worth mentioning," "In conclusion,"
+   "The future looks bright," section-ending recaps.
+8. **Synonym cycling** — "the platform... the solution... the tool... the system." Repeat the
+   product's name; that's branding, not bad writing.
+
+### AI vocabulary (avoid, or use at most once per page)
+
+delve, leverage, harness, unlock, unleash, elevate, empower, streamline, seamless, robust,
+vibrant, crucial, pivotal, cutting-edge, game-changing, groundbreaking, revolutionize,
+transform, supercharge, boast, showcase, underscore, foster, garner, bolster, meticulous,
+comprehensive, holistic, landscape, tapestry, testament, journey, realm, synergy, ecosystem,
+"valuable insights," "in today's fast-paced world," "ever-evolving," "at its core."
+
+Swap for the concrete alternative: leverage → use; seamless → say what actually happens ("no
+re-login"); robust → say the number; streamline → name the saved step or time.
+
+**Co-occurrence is the fingerprint:** one "vibrant" is a word choice; "vibrant" + "seamless" +
+"elevate" in the same section reads as generated. If two or more appear near each other,
+rewrite the section.
+
+### Formatting tells
+
+- **Em dashes:** max ~1 per paragraph — more becomes a tic. Prefer commas, periods, parentheses.
+- **Bold:** at most one decisive phrase per section, never mechanical **key phrase** bolding.
+- **Bullets:** don't shape every list as "**Label:** explanation." Vary structure and counts.
+- **No emoji** as bullets or heading decoration (🚀 ✨ 💡).
+- **Headings:** consistent case per brand style; don't default to Rigid Title Case Everywhere.
+- **Rhythm:** vary paragraph and sentence lengths. Uniform blocks read as generated.
+
+### Final artifact sweep
+
+Before delivering, search the text for leftover generation debris: `[placeholders]`,
+`{variables}`, markdown leaking into HTML, `utm_` parameters in links, "As an AI," "as of my
+last update," and openings like "Certainly! Here's..."
+
+The goal is not to pass an AI detector — it's copy so specific to this product, this customer,
+and this voice that it couldn't have come from a generic prompt.
 
 ---
 
@@ -126,6 +190,8 @@ Puns and wit make copy memorable — but only if it fits the brand and doesn't u
 **For comprehensive headline formulas**: See [references/copy-frameworks.md](references/copy-frameworks.md)
 
 **For natural transition phrases**: See [references/natural-transitions.md](references/natural-transitions.md)
+
+**For the full AI-tells catalog and sweep checklist**: See [references/ai-writing-signs.md](references/ai-writing-signs.md)
 
 **Subheadline**
 
@@ -265,3 +331,9 @@ For headlines and CTAs, provide 2-3 options:
 
 - Page title (for SEO)
 - Meta description
+
+### AI-Tells Sweep (always)
+
+Before delivering, run the final sweep from
+[references/ai-writing-signs.md](references/ai-writing-signs.md) on the finished copy and fix
+what it catches. Don't report the checklist itself — just deliver copy that passes it.

--- a/.claude/skills/copywriting/references/ai-writing-signs.md
+++ b/.claude/skills/copywriting/references/ai-writing-signs.md
@@ -1,0 +1,211 @@
+# Signs of AI Writing — Full Catalog
+
+Adapted for marketing copy from Wikipedia's *Signs of AI writing* field guide. These are patterns
+readers (and editors, and customers) have learned to recognize as machine-generated. Any single
+occurrence is fine; density is what kills credibility. Scan every draft against this catalog before
+delivering.
+
+**Key insight from the research:** AI-vocabulary words don't appear alone — where one appears,
+others follow predictably. One "vibrant" is a word choice; "vibrant" + "boasts" + "seamless" +
+"elevate" in the same section is a fingerprint. Heavy LLM users spot this instantly (~90% accuracy).
+
+---
+
+## 1. Vocabulary Tells
+
+### Overused AI words (avoid, or use at most once per page)
+
+**Verbs:** delve, boast, underscore, showcase, foster, garner, bolster, elevate, empower,
+streamline, leverage, harness, unlock, unleash, navigate, embark, revolutionize, transform,
+supercharge, enhance, ensure, facilitate, optimize, utilize
+
+**Adjectives:** vibrant, crucial, pivotal, key, seamless, robust, cutting-edge, groundbreaking,
+game-changing, innovative, meticulous, intricate, enduring, renowned, comprehensive, holistic,
+dynamic, unparalleled, effortless
+
+**Nouns:** landscape, tapestry, testament, journey, realm, synergy, ecosystem (metaphorical),
+interplay, intricacies, insights ("valuable insights"), solutions (generic)
+
+**Connectives:** additionally, moreover, furthermore, notably, importantly, "in today's
+fast-paced world," "in the ever-evolving landscape of," "at its core," "when it comes to"
+
+### Substitution guide
+
+| AI tell | Write instead |
+| --- | --- |
+| delve into | look at, dig into, cover |
+| leverage / harness / utilize | use |
+| seamless | say what actually happens ("no re-login," "one click") |
+| robust | say the number ("handles 10k req/s") |
+| empower / enable | let, help |
+| streamline / optimize | name the saved step or time |
+| unlock / unleash | get, start |
+| elevate / enhance | improve — or name the improvement |
+| journey | setup, first week, onboarding — the concrete thing |
+| ecosystem / landscape | market, tools, product — the concrete thing |
+
+---
+
+## 2. Sentence-Pattern Tells
+
+### Negative parallelisms
+
+The single most recognizable AI construction family. All variants:
+
+- "It's not just X, it's Y" / "Not just X — Y"
+- "Not only... but also..."
+- "It's not about X; it's about Y"
+- "No X, no Y, just Z"
+- "X rather than Y" (as a recurring pattern)
+
+**Fix:** State Y directly. "It's not just a dashboard, it's a command center" → "See every
+deployment, alert, and rollback in one screen."
+
+### Rule of three
+
+Triplets everywhere: "faster, simpler, smarter" • "plan, build, and ship" • three adjectives, three
+benefits, three bullet groups, three of everything. One deliberate triad per page is rhetoric; a
+triad in every section is a template.
+
+**Fix:** Vary list lengths. Two strong items beat three padded ones.
+
+### Superficial "-ing" analysis clauses
+
+Present-participle tails that bolt hollow significance onto a sentence:
+
+- "...**ensuring** your team stays aligned"
+- "...**highlighting** our commitment to quality"
+- "...**empowering** users to do more"
+- "...**reflecting** our dedication to innovation"
+- also: fostering, showcasing, underscoring, emphasizing, contributing to, cultivating
+
+**Fix:** Cut the clause, or promote it to its own sentence with a concrete claim.
+
+### Avoidance of "is" and "has"
+
+AI swaps plain copulas for inflated verbs:
+
+- "serves as / stands as / represents / marks / operates as" → **is**
+- "boasts / features / offers / maintains" → **has**
+
+"The platform serves as a comprehensive solution for..." → "The platform is..."
+(or better: just say what it does).
+
+### Significance inflation
+
+Generic claims of importance replacing specific facts: "plays a vital/pivotal/crucial role,"
+"is a testament to," "marks a key turning point," "leaves an indelible mark," "sets the stage for,"
+"reflects broader trends," "cementing its position as." Marketing equivalent: "trusted by
+industry leaders" with no names, "award-winning" with no award.
+
+**Fix:** Replace every importance claim with the fact that would prove it.
+
+### Vague attribution
+
+"Experts agree," "industry reports show," "studies suggest," "many teams find" — weasel
+authority with no source. In copy this reads as fabrication and creates legal risk.
+
+**Fix:** Name the source, the number, and the date — or delete the claim.
+
+### Formulaic conclusions
+
+"Despite these challenges, X continues to..." • section-ending summaries that restate the
+section • "In conclusion" • "The future looks bright." Endings should land on a CTA or a
+concrete next step, not a recap.
+
+### Didactic disclaimers
+
+"It's important to note that..." • "It's worth mentioning..." • "Keep in mind that..." •
+"Remember," — lecture framing, not copy.
+
+### Elegant variation (synonym cycling)
+
+Calling the product "the platform," then "the solution," then "the tool," then "the system" to
+avoid repeating its name. Humans repeat the product's name; that's branding. Repeat it.
+
+---
+
+## 3. Tone Tells
+
+- **Press-release voice:** "We are thrilled/excited/proud to announce..." — nobody reads a
+  landing page to learn how the company feels.
+- **Travel-brochure adjectives:** nestled, vibrant, rich, "in the heart of," "natural beauty,"
+  "a diverse array of."
+- **Uniform enthusiasm:** every feature described with the same energy. Real copy has a
+  hierarchy — one hero claim, supporting facts stated plainly.
+- **Relentless positivity with zero specifics:** if every sentence could describe a competitor
+  equally well, it's filler.
+
+---
+
+## 4. Formatting Tells
+
+- **Em-dash overuse** — like this — several times per paragraph — becomes a tic. Max ~1 per
+  paragraph; prefer commas, periods, or parentheses.
+- **Boldface overuse:** bolding **key phrases** in **every sentence** as mechanical emphasis.
+  Bold at most one decisive phrase per section.
+- **Inline-header bullet lists:** every bullet shaped "**Label:** explanation sentence." One list
+  like this is structure; every list like this is a template.
+- **Rule-of-three bullet groups:** exactly three bullets under every heading.
+- **Title Case in Every Heading And Subheading:** pick sentence case or title case per brand
+  style, but AI defaults to rigid Title Case everywhere.
+- **Emoji as section markers:** 🚀 ✨ 💡 prefixing headings or bullets.
+- **Thematic breaks (`---`) before every heading** and heading levels that skip (## → ####).
+- **Curly quotes/apostrophes mixed with straight ones** — sign of unedited paste; normalize to
+  one style.
+- **Tables used for prose** that should be sentences.
+
+---
+
+## 5. Structure Tells
+
+- Every section has the same shape: heading → one intro sentence → three bullets → wrap-up line.
+- Section-ending summary sentences that restate what was just said.
+- An explicit "Conclusion" section on a landing page.
+- Uniform paragraph lengths throughout. Humans write long-short-long; vary rhythm.
+- Headline, subheadline, and first section that all say the same thing three ways.
+
+---
+
+## 6. Leftover-Artifact Tells (instant credibility killers)
+
+Always search the final text for these before delivering:
+
+- Placeholder text: `[Company Name]`, `[insert benefit]`, `{product}`, "Lorem"
+- LLM citation debris: `oaicite`, `contentReference`, `turn0search0`, `attribution`, `:::`
+- Markdown syntax leaking into rendered HTML (`**bold**`, `##`)
+- `utm_source=` / `utm_campaign=` parameters in copied links
+- Knowledge-cutoff or self-referential language: "As of my last update," "I cannot browse,"
+  "As an AI"
+- Prompt-refusal fragments or an answer that begins "Certainly! Here's..."
+
+---
+
+## 7. What NOT to over-correct (weak indicators)
+
+These are *not* reliable AI tells on their own — don't contort copy to avoid them:
+
+- Lists and bullets per se (humans use them; the tell is uniform, templated lists)
+- Positive language per se (it's marketing; the tell is unspecific positivity)
+- Any single word from the vocabulary list used once, deliberately
+- Long copy (long ≠ generated; padded ≠ long)
+- Occasional em dashes, an occasional triad — the tell is density and regularity
+
+The goal is not to pass a detector. It's copy so specific to this product, this customer, and
+this voice that it *couldn't* have been generated from a generic prompt.
+
+---
+
+## Final sweep checklist
+
+1. Count AI-vocabulary words (§1) — more than ~2 per page section = rewrite.
+2. Grep for "not just", "not only", "isn't just", "rather than" — rewrite each hit.
+3. Count triads — keep at most one deliberate one per page.
+4. Find every "-ing" tail clause — cut or make concrete.
+5. Replace "serves as / boasts / features" with "is / has" (or a concrete verb).
+6. Every importance claim → replaced by the fact that proves it, or deleted.
+7. Every vague attribution → named source or deleted.
+8. Em dashes ≤ 1 per paragraph; bold ≤ 1 phrase per section; no emoji bullets.
+9. Vary bullet counts, paragraph lengths, and sentence openings.
+10. Search for artifacts (§6): brackets, `oaicite`, `utm_`, markdown leaks, "As an AI".
+11. Read aloud. Anything you'd never say to a customer face-to-face gets rewritten.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,111 @@
+# Product
+
+## Register
+
+brand
+
+## Platform
+
+web
+
+## Users
+
+Quem constrói software para a educação brasileira: desenvolvedores e times de
+produto de edtechs, integradores de sistemas de gestão escolar, e equipes
+técnicas de secretarias e redes de ensino. Chegam com um problema concreto e
+pouco tempo — precisam dos códigos e textos oficiais da BNCC dentro do produto
+deles hoje, não de mais um PDF para raspar. O contexto de uso é o do
+desenvolvedor avaliando se pode confiar numa fonte de dados: ele vai ler,
+desconfiar, testar uma chamada e decidir em minutos.
+
+Existe um segundo leitor que não escreve código — gestor de rede, coordenador
+pedagógico, pessoa de política pública — que chega para entender o que é isso e
+se dá para confiar. A página precisa não perdê-lo, mas o desenvolvedor é quem
+converte.
+
+## Product Purpose
+
+Expor toda a Base Nacional Comum Curricular como API pública, gratuita e
+estável, para que ninguém mais precise extrair a BNCC de PDF na mão. Sucesso é
+a BNCC API virar a camada de dado curricular que os produtos educacionais
+brasileiros assumem como dada — e o projeto se manter no ar sem depender de
+cobrar por isso.
+
+## Positioning
+
+A BNCC inteira, fiel ao documento oficial, gratuita e auditável — mantida como
+bem público, com as contas abertas.
+
+## Conversion & proof
+
+- CTA primário: criar conta e gerar a API key (`/portal/signup`). Secundário,
+  para quem ainda não vai se cadastrar: o guia de início rápido (`/guia`).
+- A linha que fica depois de 10 segundos: toda a BNCC, de graça, em uma API que
+  não inventa código.
+- Escada de crenças, nesta ordem: (1) isso cobre a BNCC inteira, não uma
+  amostra; (2) o texto é fiel ao documento oficial e dá para auditar; (3) é
+  gratuito de verdade, sem pegadinha nem cartão; (4) não vai sumir amanhã nem
+  quebrar meu contrato; (5) começar custa minutos, não uma reunião.
+- Proof disponível: o snapshot versionado e a auditoria de extração
+  (`scripts/audit_extraction.py`, 0 achados ERROR); a seção pública de
+  transparência com uso real e custo real de infraestrutura; o código aberto sob
+  MIT. Não há depoimentos, logos de clientes nem imprensa — a prova é o dado e a
+  prestação de contas, não a validação social.
+
+## Brand Personality
+
+Cívico, transparente, generoso. A voz é de quem construiu uma coisa pública e
+está prestando contas dela: direta, sem hype, sem vender. Assume que o leitor é
+competente e não precisa ser convencido com adjetivo. Admite limite com a mesma
+naturalidade com que mostra número — a seção que diz "R$ 0 de apoio recebido"
+é a voz da marca, não uma exceção a ela. A emoção alvo é confiança tranquila,
+com um fundo de convite: isso aqui é seu também.
+
+## Anti-references
+
+Três coisas que esta página não pode parecer:
+
+Site de startup SaaS — hero com gradiente, grid infinito de cards com ícone,
+selo de investidor, print de dashboard flutuando. É o visual mais saturado da
+web e mataria a leitura de bem público.
+
+Portal de governo — gov.br, densidade burocrática de links, cara de sistema
+legado. O risco natural da lane cívica, e o que faria o desenvolvedor fechar a
+aba.
+
+Revista editorial tipográfica — serifada display em itálico, capitulares,
+colunas com filete, metadados em maiúsculas espaçadas. Lane saturada e sem
+relação com o que o produto é.
+
+Sem fotografia de banco de imagens. O dado é a imagem: visualizações da própria
+BNCC, cobertura curricular, código real de resposta.
+
+## Design Principles
+
+**Praticar o que se prega.** O projeto vende dado auditável e contas abertas; a
+página precisa ser ela mesma auditável e aberta. Número na tela é número real
+puxado do banco, nunca ilustração.
+
+**Mostrar, não adjetivar.** "1.703 habilidades" e uma resposta JSON real valem
+mais que "completo e confiável". Toda afirmação da página deve ter como ser
+verificada por quem lê.
+
+**Admitir limite em voz alta.** O que é não-oficial, o que é gerado por IA, o
+que ainda não existe e quanto o projeto já recebeu de apoio (zero) aparecem com
+o mesmo destaque das conquistas. A honestidade é o diferencial competitivo.
+
+**Bem público, não produto grátis.** O tom é de infraestrutura compartilhada
+com as contas na mesa, não de plano free esperando upsell.
+
+**Minutos até a primeira chamada.** Cada seção é medida por quanto aproxima o
+leitor de uma requisição bem-sucedida. O que não aproxima, sai.
+
+## Accessibility & Inclusion
+
+WCAG 2.2 AA como meta explícita e verificada, não aspiração. Texto corrido
+≥4.5:1 contra o fundo, texto grande ≥3:1, foco sempre visível, nenhuma
+informação transmitida só por cor (os gráficos de custo por serviço precisam de
+rótulo além do matiz). Alvos de toque ≥44px. `prefers-reduced-motion` com
+alternativa real em toda animação. Conteúdo funcional sem JavaScript, como já
+acontece hoje no menu e nos formulários — degradação graciosa é requisito, não
+cortesia.

--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -6,25 +6,74 @@
    /guia e onboarding — sem estilos inline nos templates.
    ========================================================================= */
 
-/* ------------------------------ Tokens ---------------------------------- */
+/* ------------------------------ Tokens ----------------------------------
+   Paleta em OKLCH, exceto --brand, fixado no hex exato da identidade.
+   Estratégia de cor: COMMITTED — o azul da marca carrega superfície (bandas
+   inteiras), não é só cor de botão. Contraste de cada par verificado; os
+   números nos comentários são WCAG reais, não estimativa.
+
+   Regra dura: --amber NUNCA é texto sobre fundo claro (1.61:1). Ele é
+   preenchimento, marcador e display sobre azul profundo (6.19:1). */
 :root {
-  --bg: #ffffff;
-  --bg-soft: #f6f7f9;
-  --bg-sunken: #f0f2f5;
-  --fg: #0e1117;
-  --fg-muted: #5a6270;
-  --fg-subtle: #8a92a0;
-  --border: #e7e9ee;
-  --border-strong: #d6d9e0;
-  --brand: #1b4dff;
-  --brand-strong: #1640d9;
-  --brand-fg: #ffffff;
-  --brand-soft: #eef2ff;
-  --accent: #0d9488;
-  --danger: #b42318;
-  --danger-soft: #fef3f2;
-  --ok: #0a7d5a;
-  --ok-soft: #e7f7f0;
+  color-scheme: light dark;
+
+  /* Marca — identidade travada (logo, theme-color, og-image dependem disto) */
+  --brand: #1b4dff;                        /* branco sobre: 5.91:1 */
+  --brand-lift: oklch(0.575 0.212 265);    /* hover; branco sobre: 4.58:1 */
+  --brand-deep: oklch(0.392 0.196 265);    /* banda drenched; branco: 10.13:1 */
+  --brand-deeper: oklch(0.268 0.128 265);  /* banda mais densa; branco: 15.62:1 */
+  --brand-wash: oklch(0.955 0.028 265);    /* fundo tênue, tingido para a marca */
+  --brand-fg: oklch(0.995 0.002 265);      /* texto SOBRE --brand (botão) */
+  --band-ink: oklch(0.990 0.004 265);      /* texto SOBRE a banda drenched */
+  --amber: oklch(0.842 0.150 84);          /* #ffc53d do logo — só fill/display */
+  --amber-deep: oklch(0.660 0.145 68);     /* quando o âmbar precisa ser texto */
+
+  /* Rampa da barra de cobertura. Fixa nos DOIS temas: é dado, não superfície,
+     e os rótulos em branco por cima precisam de contraste estável. Nenhuma
+     passa de L 0.575, o ponto em que o branco ainda fecha 4.5:1. */
+  --cov-1: oklch(0.392 0.196 265);         /* branco sobre: 10.13:1 */
+  --cov-2: oklch(0.512 0.271 265);         /* branco sobre:  6.28:1 */
+  --cov-3: oklch(0.575 0.212 265);         /* branco sobre:  4.58:1 */
+
+  /* Neutros tingidos para o matiz da marca (265), nunca para o quente */
+  --paper: oklch(0.993 0.003 265);
+  --surface: oklch(0.968 0.007 265);
+  --sunken: oklch(0.940 0.010 265);
+  --ink: oklch(0.215 0.026 265);           /* sobre paper: 17.24:1 */
+  --ink-muted: oklch(0.468 0.030 265);     /* sobre paper: 6.79:1 */
+  --ink-subtle: oklch(0.540 0.029 265);    /* sobre paper: 4.97:1 — piso do AA */
+  --line: oklch(0.905 0.012 265);
+  --line-strong: oklch(0.855 0.016 265);
+
+  /* Aliases legados: portal, admin, /guia e onboarding consomem estes nomes.
+     Mantidos para o sistema novo valer em todas as telas sem reescrever 18
+     templates de uma vez. */
+  --bg: var(--paper);
+  --bg-soft: var(--surface);
+  --bg-sunken: var(--sunken);
+  --fg: var(--ink);
+  --fg-muted: var(--ink-muted);
+  --fg-subtle: var(--ink-subtle);
+  --border: var(--line);
+  --border-strong: var(--line-strong);
+  --brand-strong: var(--brand-lift);
+  --brand-soft: var(--brand-wash);
+  --accent: var(--brand);
+
+  /* O <style> inline do admin consome estes nomes com fallback claro fixo.
+     Enquanto --surface não existia ele caía no fallback e o painel era
+     claro-só; agora que existe, sem estes aliases o admin ficaria com texto
+     escuro sobre fundo escuro no tema escuro. */
+  --text: var(--ink);
+  --text-muted: var(--ink-muted);
+  --surface-hover: var(--sunken);
+  --primary: var(--brand);
+  --primary-soft: var(--brand-wash);
+
+  --danger: oklch(0.505 0.185 27);
+  --danger-soft: oklch(0.962 0.018 27);
+  --ok: oklch(0.505 0.108 162);
+  --ok-soft: oklch(0.955 0.035 162);
   /* Séries do gráfico de uso (BI): total (marca) vs. bem-sucedidas (verde). */
   --chart-total: var(--brand);
   --chart-success: #0a9d6e;
@@ -40,45 +89,99 @@
   --code-fg: #e2e8f0;
   --code-key: #7dd3fc;
   --code-val: #86efac;
-  --shadow-sm: 0 1px 2px rgb(15 23 42 / 0.05);
-  --shadow: 0 1px 2px rgb(15 23 42 / 0.05), 0 12px 28px -10px rgb(15 23 42 / 0.12);
-  --shadow-lg: 0 24px 60px -18px rgb(15 23 42 / 0.24);
+  --shadow-sm: 0 1px 2px oklch(0.215 0.026 265 / 0.05);
+  --shadow: 0 1px 2px oklch(0.215 0.026 265 / 0.05), 0 12px 28px -10px oklch(0.215 0.026 265 / 0.12);
+  --shadow-lg: 0 24px 60px -18px oklch(0.215 0.026 265 / 0.24);
   --radius-sm: 8px;
   --radius: 12px;
   --radius-lg: 18px;
   --maxw: 72rem;
   --font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Escala tipográfica — razão 1.25 (o skill reprova escalas achatadas, que
+     lêem como indecisão). Fluida via clamp; o teto de display fica em 5rem,
+     abaixo do limite de 6rem. */
+  --t-xs: 0.79rem;
+  --t-sm: 0.889rem;
+  --t-base: 1rem;
+  --t-md: 1.125rem;
+  --t-lg: clamp(1.25rem, 0.6vw + 1.1rem, 1.406rem);
+  --t-xl: clamp(1.5rem, 1.2vw + 1.2rem, 1.802rem);
+  --t-2xl: clamp(1.85rem, 2.1vw + 1.35rem, 2.441rem);
+  --t-3xl: clamp(2.25rem, 3.4vw + 1.4rem, 3.052rem);
+  --t-display: clamp(2.5rem, 5vw + 1rem, 4.5rem);
+
+  /* Escala de espaçamento fluida — o ritmo respira em viewport grande em vez
+     de congelar num valor fixo. */
+  --s-1: 0.25rem;
+  --s-2: 0.5rem;
+  --s-3: 0.75rem;
+  --s-4: 1rem;
+  --s-5: 1.5rem;
+  --s-6: 2rem;
+  --s-7: clamp(2.5rem, 3vw, 3.5rem);
+  --s-8: clamp(3.5rem, 5vw, 5.5rem);
+  --s-9: clamp(5rem, 8vw, 8rem);
+
+  /* Z-index semântico — sem 999 nem 9999 espalhados pelo arquivo. */
+  --z-base: 1;
+  --z-sticky: 50;
+  --z-nav: 60;
+  --z-backdrop: 70;
+  --z-modal: 80;
+  --z-toast: 90;
+  --z-skip: 100;
+
+  /* Curvas: saída exponencial, sem bounce nem elástico. */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);        /* out-quint */
+  --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);    /* out-expo */
+  --dur-fast: 0.16s;
+  --dur: 0.28s;
+  --dur-slow: 0.6s;
 }
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0b0d12;
-    --bg-soft: #12151d;
-    --bg-sunken: #0e1117;
-    --fg: #eceef2;
-    --fg-muted: #9aa2b1;
-    --fg-subtle: #6b7280;
-    --border: #23272f;
-    --border-strong: #333844;
-    --brand: #6b8aff;
-    --brand-strong: #86a0ff;
-    --brand-soft: #161d33;
-    --danger: #f97066;
-    --danger-soft: #2a1715;
-    --ok: #34d399;
-    --ok-soft: #0f2a22;
-    --chart-total: #6b8aff;
-    --chart-success: #34d399;
-    --chart-total-fill: rgba(107, 138, 255, 0.16);
-    --chart-success-fill: rgba(52, 211, 153, 0.14);
-    --cost-banco: #5c7cfa;
-    --cost-servidor: #38d9a9;
-    --cost-ia: #ffa94d;
-    --cost-outros: #adb5bd;
-    --code-bg: #0a0e18;
-    --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.4);
-    --shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 16px 36px -14px rgb(0 0 0 / 0.6);
-    --shadow-lg: 0 30px 70px -20px rgb(0 0 0 / 0.7);
+    /* Sem preto puro: o fundo escuro também é tingido para o matiz da marca. */
+    --paper: oklch(0.178 0.019 265);
+    --surface: oklch(0.222 0.023 265);
+    --sunken: oklch(0.148 0.017 265);
+    --ink: oklch(0.945 0.008 265);          /* sobre paper: 16.09:1 */
+    --ink-muted: oklch(0.740 0.021 265);    /* sobre paper: 8.19:1 */
+    --ink-subtle: oklch(0.630 0.024 265);   /* sobre paper: 5.38:1 */
+    --line: oklch(0.298 0.024 265);
+    --line-strong: oklch(0.365 0.028 265);
+
+    /* No escuro o azul da marca precisa clarear para virar texto legível;
+       a banda drenched inverte e usa o azul profundo como superfície. */
+    --brand: oklch(0.700 0.138 265);        /* sobre paper: 6.96:1 */
+    --brand-lift: oklch(0.775 0.115 265);
+    --brand-deep: oklch(0.330 0.150 265);
+    --brand-deeper: oklch(0.242 0.110 265);
+    --brand-wash: oklch(0.268 0.078 265);   /* ink sobre: 13.06:1 */
+    /* No escuro --brand clareia, então a tinta sobre ele escurece. Mas a
+       banda drenched continua escura, e a tinta dela segue clara: são dois
+       papéis diferentes e confundi-los deixava o hero preto-no-azul. */
+    --brand-fg: oklch(0.145 0.030 265);
+    --band-ink: oklch(0.965 0.006 265);
+    --amber: oklch(0.842 0.150 84);
+    --amber-deep: oklch(0.800 0.150 78);
+
+    --danger: oklch(0.700 0.170 27);
+    --danger-soft: oklch(0.268 0.070 27);
+    --ok: oklch(0.760 0.140 162);
+    --ok-soft: oklch(0.268 0.055 162);
+    --chart-success: oklch(0.760 0.140 162);
+    --chart-total-fill: oklch(0.700 0.138 265 / 0.18);
+    --chart-success-fill: oklch(0.760 0.140 162 / 0.16);
+    --cost-banco: oklch(0.680 0.150 265);
+    --cost-servidor: oklch(0.790 0.135 168);
+    --cost-ia: oklch(0.800 0.135 62);
+    --cost-outros: oklch(0.720 0.020 265);
+    --code-bg: oklch(0.148 0.024 265);
+    --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
+    --shadow: 0 1px 2px oklch(0 0 0 / 0.4), 0 16px 36px -14px oklch(0 0 0 / 0.6);
+    --shadow-lg: 0 30px 70px -20px oklch(0 0 0 / 0.7);
   }
 }
 
@@ -100,32 +203,47 @@ body {
 }
 a { color: var(--brand); text-decoration: none; }
 a:hover { text-decoration: underline; }
-h1, h2, h3 { line-height: 1.15; letter-spacing: -0.021em; text-wrap: balance; }
-h1 { font-size: clamp(2.25rem, 5.2vw, 3.6rem); margin: 0 0 1.1rem; letter-spacing: -0.03em; }
-h2 { font-size: clamp(1.6rem, 3.2vw, 2.15rem); margin: 2.5rem 0 1rem; }
+h1, h2, h3, h4 { line-height: 1.14; letter-spacing: -0.022em; text-wrap: balance; }
+h4 { font-size: var(--t-base); margin: 0 0 var(--s-2); }
+h1 { font-size: var(--t-3xl); margin: 0 0 var(--s-4); letter-spacing: -0.032em; }
+h2 { font-size: var(--t-2xl); margin: var(--s-6) 0 var(--s-4); letter-spacing: -0.028em; }
+h3 { font-size: var(--t-lg); }
 p { text-wrap: pretty; }
+/* Todo número da página é dado real; alinhamento tabular para poder comparar
+   colunas de cifra e contagem sem dançar. */
+.tabular, .stat strong, .metric-value, .kpi-value, .tp-value, .tp-stat dd { font-variant-numeric: tabular-nums; }
 .muted { color: var(--fg-muted); }
-.container { max-width: var(--maxw); margin: 0 auto; padding: 0 1.5rem; }
-.section { padding: 4.5rem 0; }
+.container { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--s-5); }
+.section { padding: var(--s-8) 0; }
 .section-narrow { max-width: 52rem; }
 /* Header sticky: âncoras (#apoie, #casos-de-uso…) não escondem sob a barra. */
 :where(section, [id])[id] { scroll-margin-top: 5rem; }
-.lead { font-size: 1.2rem; line-height: 1.55; color: var(--fg-muted); max-width: 40rem; }
+.lead {
+  font-size: var(--t-md); line-height: 1.6; color: var(--fg-muted);
+  max-width: 65ch; /* teto de medida: o skill trava linha entre 65 e 75ch */
+}
 
 /* Foco visível e movimento reduzido (a11y) */
-a:focus-visible, button:focus-visible, .btn:focus-visible {
+a:focus-visible, button:focus-visible, .btn:focus-visible, summary:focus-visible {
   outline: 3px solid var(--brand); outline-offset: 2px; border-radius: 6px;
 }
-.btn, a, button { transition: opacity 0.18s ease, background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease; }
+/* Dentro da banda azul o foco precisa contrastar com o azul, não com o papel. */
+.band-brand a:focus-visible, .band-brand button:focus-visible, .band-brand .btn:focus-visible {
+  outline-color: var(--amber);
+}
+.btn, a, button {
+  transition: opacity var(--dur-fast) var(--ease-out), background-color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+}
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { transition: none !important; animation: none !important; }
 }
 
 /* ------------------------------ Header ---------------------------------- */
 .site-header {
-  position: sticky; top: 0; z-index: 50;
+  position: sticky; top: 0; z-index: var(--z-sticky);
   border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
 }
 @supports (backdrop-filter: blur(8px)) {
   .site-header { backdrop-filter: saturate(140%) blur(10px); }
@@ -159,9 +277,13 @@ a:focus-visible, button:focus-visible, .btn:focus-visible {
   border-radius: 10px; color: var(--fg); cursor: pointer;
 }
 .nav-toggle:hover { background: var(--bg-soft); }
+/* "hidden" é atributo global de HTML e não vale para elementos SVG (outro
+   namespace), então a regra [hidden]{display:none} do navegador não pegava os
+   ícones do menu e os dois apareciam juntos no celular. */
+svg[hidden] { display: none; }
 .skip-link {
   position: absolute; left: -999px; top: 0; background: var(--brand);
-  color: #fff; padding: 0.5rem 1rem; z-index: 100;
+  color: var(--brand-fg); padding: 0.5rem 1rem; z-index: var(--z-skip);
 }
 .skip-link:focus { left: 0; }
 .sr-only {
@@ -170,27 +292,36 @@ a:focus-visible, button:focus-visible, .btn:focus-visible {
 }
 
 /* ------------------------------ Botões ----------------------------------- */
+/* Botão: presença por peso e cor sólida, não por brilho difuso. O halo azul
+   soprado sob o CTA é assinatura de landing de SaaS e some aqui. */
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem;
-  padding: 0.68rem 1.25rem; border-radius: var(--radius); min-height: 44px;
+  padding: 0.7rem 1.3rem; border-radius: var(--radius-sm); min-height: 44px;
   background: var(--brand); color: var(--brand-fg); font-weight: 600;
-  font-size: 1rem; font-family: inherit; line-height: 1.2; letter-spacing: -0.01em;
+  font-size: var(--t-base); font-family: inherit; line-height: 1.2; letter-spacing: -0.011em;
   border: 1px solid transparent; cursor: pointer;
-  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease,
-    transform 0.18s ease, box-shadow 0.18s ease;
+  transition: background-color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out),
+    transform var(--dur-fast) var(--ease-out);
 }
-.btn:hover { text-decoration: none; background: var(--brand-strong); }
-/* CTA primário: elevação discreta e micro-lift (hierarquia de ação sem estridência). */
-.btn:not(.btn-secondary):not(.btn-oauth):not(.btn-danger) {
-  box-shadow: 0 1px 2px rgb(27 77 255 / 0.16), 0 8px 20px -8px rgb(27 77 255 / 0.42);
+.btn:hover { text-decoration: none; background: var(--brand-lift); }
+.btn:active { transform: translateY(1px); }
+.btn-secondary {
+  background: transparent; color: var(--fg); border-color: var(--line-strong); box-shadow: none;
 }
-.btn:not(.btn-secondary):not(.btn-oauth):not(.btn-danger):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgb(27 77 255 / 0.18), 0 12px 26px -8px rgb(27 77 255 / 0.5);
+.btn-secondary:hover { background: var(--surface); border-color: var(--fg-subtle); }
+/* Sobre a banda azul os botões invertem: o primário vira papel, o secundário
+   vira contorno claro. Sem isso o CTA sumiria dentro da própria cor. */
+.band-brand .btn { background: var(--band-ink); color: var(--brand-deep); }
+.band-brand .btn:hover { background: var(--amber); color: var(--brand-deeper); }
+.band-brand .btn-secondary {
+  background: transparent; color: var(--band-ink);
+  border-color: color-mix(in oklab, var(--band-ink) 45%, transparent);
 }
-.btn:active { transform: translateY(0); }
-.btn-secondary { background: var(--bg); color: var(--fg); border-color: var(--border-strong); box-shadow: var(--shadow-sm); }
-.btn-secondary:hover { background: var(--bg-soft); border-color: var(--fg-subtle); }
+.band-brand .btn-secondary:hover {
+  background: color-mix(in oklab, var(--band-ink) 12%, transparent);
+  border-color: var(--band-ink); color: var(--band-ink);
+}
 .btn-danger { background: var(--danger); }
 .btn-danger:hover { background: var(--danger); opacity: 0.88; }
 .btn-lg { padding: 0.85rem 1.6rem; font-size: 1.05rem; min-height: 50px; }
@@ -297,158 +428,255 @@ input[type="password"]::-ms-clear { display: none; }
   border-radius: 999px; background: var(--accent); color: #fff; vertical-align: middle;
 }
 .badge-muted { background: var(--border); color: var(--fg-muted); }
+/* Aviso: borda completa + fundo tingido. A tarja lateral colorida (border-left
+   grosso) é banida — é o tell mais reconhecível de UI gerada por IA. */
 .notice {
-  border-left: 3px solid var(--accent); background: var(--bg-soft);
-  padding: 0.75rem 1rem; border-radius: 6px; margin: 1rem 0;
+  border: 1px solid color-mix(in oklab, var(--brand) 30%, var(--line));
+  background: var(--brand-wash); color: var(--fg);
+  padding: var(--s-3) var(--s-4); border-radius: var(--radius-sm); margin: var(--s-4) 0;
 }
-.notice-danger { border-left-color: var(--danger); background: var(--danger-soft); }
+.notice-danger {
+  border-color: color-mix(in oklab, var(--danger) 38%, var(--line));
+  background: var(--danger-soft);
+}
 
 /* =========================================================================
    Landing comercial (v2)
    ========================================================================= */
+/* Rótulo de contexto acima do título de uma página de documentação. Sem
+   caixa-alta com tracking largo: o "eyebrow" miúdo repetido acima de cada
+   seção é scaffolding de IA, e aqui ele aparece uma vez, como localização. */
 .eyebrow {
-  display: inline-flex; align-items: center; gap: 0.5rem;
-  font-size: 0.8rem; font-weight: 600; letter-spacing: 0.01em;
-  color: var(--fg-muted); background: var(--bg-soft); border: 1px solid var(--border);
-  padding: 0.3rem 0.85rem 0.3rem 0.7rem; border-radius: 999px; margin: 0 0 1.4rem;
-}
-.eyebrow::before {
-  content: ""; width: 0.45rem; height: 0.45rem; border-radius: 50%;
-  background: var(--accent); flex: none;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
-}
-.hero { padding: 5rem 0 4rem; }
-.hero-grid {
-  display: grid; gap: 3rem; align-items: center;
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
-}
-@media (max-width: 820px) { .hero-grid { grid-template-columns: 1fr; gap: 2.25rem; } }
-.hero .lead { font-size: 1.25rem; max-width: 34rem; }
-.hero .cta-row { margin-top: 1.75rem; }
-.hero-note {
-  font-size: 0.88rem; margin-top: 0.85rem; color: var(--fg-subtle);
-  display: inline-flex; align-items: center; gap: 0.45rem;
-}
-.hero-note::before {
-  content: ""; width: 1.05rem; height: 1.05rem; flex: none;
-  background: currentColor;
-  -webkit-mask: no-repeat center / contain url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
-  mask: no-repeat center / contain url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E");
+  display: block; margin: 0 0 var(--s-2);
+  font-size: var(--t-sm); font-weight: 500; color: var(--fg-muted);
 }
 
-/* Janela de código */
-.code-window {
-  background: var(--code-bg); color: var(--code-fg); border-radius: var(--radius-lg);
-  border: 1px solid rgb(255 255 255 / 0.08); box-shadow: var(--shadow-lg); overflow: hidden;
-  font-size: 0.88rem;
+/* Bandas full-bleed. A estratégia de cor é committed: o azul da marca carrega
+   superfície inteira em vez de aparecer só na borda de um botão. */
+.band { padding: var(--s-8) 0; }
+.band-brand { background: var(--brand-deep); color: var(--band-ink); }
+.band-brand .muted,
+.band-brand .lead { color: color-mix(in oklab, var(--band-ink) 80%, transparent); }
+/* :not(.btn) — sem isso o sublinhado de link vaza para dentro dos botões. */
+.band-brand a:not(.btn) { color: var(--band-ink); text-decoration: underline; text-underline-offset: 3px; }
+.band-brand a:not(.btn):hover { color: var(--amber); }
+.band-surface { background: var(--surface); border-block: 1px solid var(--line); }
+
+/* ------------------------------ Hero ------------------------------------
+   Uma ideia por dobra: a afirmação e a prova dela, lado a lado. Sem selo,
+   sem eyebrow, sem badge — a página abre falando. */
+.hero { padding: var(--s-9) 0 var(--s-8); }
+.hero-inner {
+  display: grid; gap: var(--s-7) var(--s-8); align-items: end;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
 }
-.code-window pre { background: transparent; border: 0; margin: 0; padding: 1.1rem 1.25rem; }
-.code-window code { color: var(--code-fg); }
-.code-window-bar {
-  display: flex; align-items: center; gap: 0.45rem;
-  padding: 0.65rem 1rem; border-bottom: 1px solid rgb(255 255 255 / 0.08);
+/* minmax(0, 1fr), não 1fr: "1fr" é minmax(auto, 1fr), e o auto impede o item
+   de encolher abaixo do conteúdo — o <pre> do registro estourava a página
+   inteira no celular. Mesma correção vale para todo grid de coluna única. */
+@media (max-width: 900px) { .hero-inner { grid-template-columns: minmax(0, 1fr); align-items: start; } }
+.hero-inner > * { min-width: 0; }
+.hero h1 {
+  font-size: var(--t-display); letter-spacing: -0.038em; line-height: 1.02;
+  margin: 0 0 var(--s-5); max-width: 20ch;
 }
-.code-window-bar .dot { width: 10px; height: 10px; border-radius: 50%; background: rgb(255 255 255 / 0.22); }
-.code-window-title { margin-left: 0.5rem; font-family: var(--mono); font-size: 0.8rem; color: rgb(255 255 255 / 0.65); }
+/* O âmbar do logo vira grifo tipográfico: sobre o azul profundo dá 6.19:1,
+   suficiente para display. Nunca use âmbar em texto corrido claro. */
+.hero h1 em { font-style: normal; color: var(--amber); }
+.hero-lead {
+  font-size: var(--t-lg); line-height: 1.5; max-width: 46ch;
+  color: color-mix(in oklab, var(--band-ink) 84%, transparent); margin: 0 0 var(--s-6);
+}
+.hero-actions { display: flex; flex-wrap: wrap; gap: var(--s-3); align-items: center; }
+/* 72% de branco sobre o azul reprovava o AA em texto pequeno; 88% passa. */
+.hero-note {
+  margin: var(--s-4) 0 0; font-size: var(--t-sm);
+  color: color-mix(in oklab, var(--band-ink) 88%, transparent);
+}
+
+/* O registro: a resposta real da API tratada como documento público, não como
+   "screenshot de produto" flutuando com sombra. Ele encosta na banda. */
+.record {
+  margin: 0; border-radius: var(--radius); overflow: hidden;
+  background: color-mix(in oklab, var(--brand-deeper) 82%, black);
+  border: 1px solid color-mix(in oklab, var(--band-ink) 18%, transparent);
+}
+.record-head {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s-3);
+  padding: var(--s-3) var(--s-4);
+  border-bottom: 1px solid color-mix(in oklab, var(--band-ink) 14%, transparent);
+  font-family: var(--mono); font-size: var(--t-xs);
+  color: color-mix(in oklab, var(--band-ink) 72%, transparent);
+}
+.record-verb { color: var(--amber); font-weight: 600; }
+.record pre {
+  background: transparent; border: 0; margin: 0; padding: var(--s-4);
+  font-size: var(--t-sm); line-height: 1.7; color: var(--code-fg);
+  overflow-x: auto;
+}
+.record code { color: inherit; }
 .tk { color: var(--code-key); }
 .tv { color: var(--code-val); }
 
-/* Faixa de números */
-.stat-strip { background: var(--bg-soft); border-block: 1px solid var(--border); }
-.stat-grid {
-  display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-  gap: 1rem 2rem; padding: 2.25rem 1.5rem; text-align: center;
+/* --------------------------- Cobertura da base ---------------------------
+   Substitui a faixa de 4 números soltos. O dado é a imagem: as três etapas
+   em proporção real, para "a BNCC inteira" ser visto e não afirmado. */
+.cov-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0 var(--s-5); }
+.cov-total-label { margin: 0; }
+.cov-total {
+  font-size: var(--t-3xl); font-weight: 800; letter-spacing: -0.04em; line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
-.stat strong {
-  display: block; font-size: 2.35rem; font-weight: 700; letter-spacing: -0.04em;
-  color: var(--fg); font-variant-numeric: tabular-nums; line-height: 1.05;
+.cov-total-label { color: var(--fg-muted); font-size: var(--t-md); }
+.cov-bar {
+  display: flex; width: 100%; height: 3.25rem; margin: var(--s-6) 0 var(--s-5);
+  border-radius: var(--radius-sm); overflow: hidden; background: var(--sunken);
 }
-.stat span { display: block; margin-top: 0.35rem; color: var(--fg-muted); font-size: 0.92rem; }
+.cov-seg {
+  display: flex; align-items: center; justify-content: center;
+  font-size: var(--t-sm); font-weight: 700; color: var(--band-ink);
+  font-variant-numeric: tabular-nums; min-width: 0; overflow: hidden;
+  transition: filter var(--dur-fast) var(--ease-out);
+}
+.cov-seg:hover { filter: brightness(1.12); }
+/* Rampa sequencial de um matiz só: as etapas são ordenadas, então a cor
+   segue a ordem. O tom mais escuro (deeper) lia como buraco na barra. */
+.cov-seg-ei { background: var(--cov-1); }
+.cov-seg-ef { background: var(--cov-2); }
+.cov-seg-em { background: var(--cov-3); }
+/* A informação não pode depender só da cor: cada segmento tem legenda com
+   rótulo textual abaixo, e o segmento estreito (EM) recebe o número lá. */
+.cov-legend {
+  list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap;
+  gap: var(--s-3) var(--s-6);
+}
+.cov-legend li { display: flex; align-items: baseline; gap: var(--s-2); font-size: var(--t-sm); }
+.cov-legend .swatch { width: 0.7rem; height: 0.7rem; border-radius: 3px; flex: none; align-self: center; }
+.cov-legend b { font-variant-numeric: tabular-nums; }
+.cov-legend span { color: var(--fg-muted); }
+.cov-note { margin: var(--s-5) 0 0; color: var(--fg-muted); font-size: var(--t-sm); max-width: 70ch; }
 
-/* Casos de uso */
-.uc-grid { grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); margin-top: 2rem; }
-.uc-card { display: flex; flex-direction: column; gap: 0.4rem; box-shadow: none; }
-.uc-card:hover { border-color: var(--border-strong); transform: translateY(-2px); box-shadow: var(--shadow); }
-.uc-card h3 { margin: 0.4rem 0 0; font-size: 1.1rem; letter-spacing: -0.01em; }
-@media (prefers-reduced-motion: reduce) { .uc-card:hover { transform: none; } }
-.uc-card p:last-child { margin-top: auto; display: flex; flex-wrap: wrap; gap: 0.4rem; }
-.uc-icon {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 2.6rem; height: 2.6rem; border-radius: 10px;
-  background: var(--brand-soft); color: var(--brand);
+/* ---------------------------- Prova de fidelidade ------------------------
+   O argumento mais forte do projeto e o mais escondido na versão anterior.
+   Layout assimétrico: a afirmação pesa mais que a lista que a sustenta. */
+.proof-grid {
+  display: grid; gap: var(--s-7) var(--s-8); align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
 }
-.uc-icon svg { width: 1.4rem; height: 1.4rem; }
+@media (max-width: 880px) { .proof-grid { grid-template-columns: minmax(0, 1fr); } }
+.proof-list { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--s-5); }
+.proof-list li { display: grid; gap: var(--s-1); padding-bottom: var(--s-5); border-bottom: 1px solid var(--line); }
+.proof-list li:last-child { border-bottom: 0; padding-bottom: 0; }
+.proof-list dfn { font-style: normal; font-weight: 650; font-size: var(--t-md); }
+.proof-list p { margin: 0; color: var(--fg-muted); max-width: 62ch; }
+.proof-figure { font-variant-numeric: tabular-nums; color: var(--brand); font-weight: 700; }
+
+/* ------------------------------ Casos de uso -----------------------------
+   Sem grid de cards idênticos e sem ladrilho de ícone arredondado acima de
+   cada título (ambos banidos pelo skill). O endpoint é a âncora visual: ele
+   é a coisa concreta que o leitor vai usar, e serve de "ícone" honesto.
+   O primeiro caso ocupa a largura toda — hierarquia, não repetição. */
+.uc-list {
+  list-style: none; margin: var(--s-6) 0 0; padding: 0;
+  display: grid; gap: 0; border-top: 1px solid var(--line);
+}
+.uc-item {
+  display: grid; gap: var(--s-2) var(--s-6); align-items: start;
+  grid-template-columns: minmax(0, 16rem) minmax(0, 1fr);
+  padding: var(--s-5) 0; border-bottom: 1px solid var(--line);
+}
+.uc-item h3 { margin: 0; font-size: var(--t-md); letter-spacing: -0.015em; }
+.uc-item p { margin: 0; color: var(--fg-muted); max-width: 68ch; }
+.uc-endpoints { display: flex; flex-wrap: wrap; gap: var(--s-2); align-content: start; }
+.uc-lead .uc-body { display: grid; gap: var(--s-2); }
+.uc-lead h3 { font-size: var(--t-xl); letter-spacing: -0.025em; }
+@media (max-width: 760px) {
+  .uc-item { grid-template-columns: minmax(0, 1fr); gap: var(--s-3); }
+  .uc-endpoints { order: 2; }
+}
+/* overflow-wrap: anywhere quebrava "relacoes" no meio da palavra. O chip
+   rola dentro de si quando não cabe, em vez de picar o identificador. */
 .endpoint {
-  display: inline-block; font-size: 0.78rem; padding: 0.2rem 0.55rem;
-  background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
-  color: var(--fg-muted); white-space: nowrap; max-width: 100%; overflow: hidden;
-  text-overflow: ellipsis;
+  display: inline-block; font-family: var(--mono); font-size: var(--t-xs);
+  padding: 0.25rem 0.5rem; background: var(--surface);
+  border: 1px solid var(--line); border-radius: 5px;
+  color: var(--fg-muted); max-width: 100%;
+  white-space: nowrap; overflow-x: auto; vertical-align: bottom;
 }
-.uc-card-cta { border-style: dashed; align-items: flex-start; justify-content: center; }
 
-/* Passos */
-.steps-grid { grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); margin: 1.5rem 0; }
-.step { position: relative; padding-top: 1.5rem; }
-.step-num {
-  position: absolute; top: -1.1rem; left: 1.1rem;
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 2.2rem; height: 2.2rem; border-radius: 50%;
-  background: var(--brand); color: var(--brand-fg); font-weight: 700;
+/* ------------------------------ Passos -----------------------------------
+   Numeração legítima: isto é de fato uma sequência ordenada, e a ordem
+   carrega informação. O skill só bane número como enfeite de seção. */
+.steps { list-style: none; counter-reset: step; margin: var(--s-6) 0; padding: 0;
+  display: grid; gap: var(--s-5); grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); }
+.step { counter-increment: step; display: grid; gap: var(--s-2); align-content: start; }
+.step::before {
+  content: counter(step); font-variant-numeric: tabular-nums;
+  font-size: var(--t-xl); font-weight: 800; line-height: 1;
+  color: var(--brand); letter-spacing: -0.04em;
 }
-.curl-block { font-size: 0.88rem; }
+.step h3 { margin: 0; font-size: var(--t-md); }
+.step p { margin: 0; color: var(--fg-muted); }
+.curl-block { font-size: var(--t-sm); background: var(--code-bg); color: var(--code-fg); border-color: transparent; }
+.curl-block code { color: inherit; }
 
-/* FAQ */
-.faq-list { max-width: 52rem; display: grid; gap: 0.75rem; margin-top: 1.5rem; }
-.faq-item {
-  border: 1px solid var(--border); border-radius: var(--radius);
-  background: var(--bg-soft);
-}
+/* ------------------------------ FAQ --------------------------------------
+   Filetes em vez de cartões empilhados: cartão aqui só adicionaria moldura
+   sem afordância nova. */
+.faq-list { max-width: 62rem; display: grid; margin-top: var(--s-6); border-top: 1px solid var(--line); }
+.faq-item { border-bottom: 1px solid var(--line); }
 .faq-item summary {
-  cursor: pointer; font-weight: 600; padding: 1rem 1.25rem;
-  list-style: none; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+  cursor: pointer; font-weight: 650; font-size: var(--t-md);
+  padding: var(--s-4) 0; list-style: none; min-height: 44px;
+  display: flex; align-items: center; justify-content: space-between; gap: var(--s-4);
 }
 .faq-item summary::-webkit-details-marker { display: none; }
 .faq-item summary::after {
-  content: ""; flex: none; width: 0.6rem; height: 0.6rem;
+  content: ""; flex: none; width: 0.65rem; height: 0.65rem; margin-right: 0.2rem;
   border-right: 2px solid var(--fg-muted); border-bottom: 2px solid var(--fg-muted);
-  transform: rotate(45deg); transition: transform 0.18s ease;
+  transform: rotate(45deg); transition: transform var(--dur-fast) var(--ease-out);
 }
 .faq-item[open] summary::after { transform: rotate(-135deg); }
-.faq-item p { margin: 0; padding: 0 1.25rem 1rem; color: var(--fg-muted); }
+.faq-item p { margin: 0; padding: 0 0 var(--s-5); color: var(--fg-muted); max-width: 70ch; }
 
-/* Apoie o projeto */
-.sponsor-section { background: var(--bg-soft); border-block: 1px solid var(--border); }
-.sponsor-grid { grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); margin-top: 1.5rem; }
-.sponsor-card { background: var(--bg); display: flex; flex-direction: column; gap: 0.5rem; }
-.sponsor-card h3 { margin: 0.25rem 0 0; }
-.sponsor-card .btn { align-self: flex-start; }
+/* --------------------------- Apoie o projeto -----------------------------
+   Três formas de apoiar, sem três cartões idênticos com ícone: uma coluna
+   de texto e o Pix como o único bloco com peso visual (é o que exige ação
+   manual do leitor). */
+.support-grid {
+  display: grid; gap: var(--s-7) var(--s-8); align-items: start; margin-top: var(--s-6);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
+}
+@media (max-width: 880px) { .support-grid { grid-template-columns: minmax(0, 1fr); } }
+.support-ways { display: grid; gap: var(--s-5); }
+.support-title { margin: 0; font-size: var(--t-lg); letter-spacing: -0.022em; }
+.support-way { display: grid; gap: var(--s-2); }
+.support-way h4 { margin: 0; font-size: var(--t-md); letter-spacing: -0.015em; }
+.support-way p { margin: 0; color: var(--fg-muted); max-width: 60ch; }
+.pix-panel h4 { margin: 0; font-size: var(--t-md); letter-spacing: -0.015em; }
+.support-way .btn { justify-self: start; margin-top: var(--s-1); }
+.pix-panel {
+  display: grid; gap: var(--s-4); padding: var(--s-5);
+  border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface);
+  justify-items: start;
+}
 .pix-qr {
-  border: 1px solid var(--border); border-radius: 8px; background: #fff;
-  padding: 6px; image-rendering: pixelated;
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  background: #fff; /* QR precisa de branco real para leitura óptica, nos dois temas */
+  padding: 8px; image-rendering: pixelated;
 }
-.pix-copy { display: flex; flex-direction: column; gap: 0.5rem; }
+.pix-copy { display: grid; gap: var(--s-3); width: 100%; }
 .pix-copy code {
-  font-size: 0.72rem; word-break: break-all; color: var(--fg-muted);
-  background: var(--bg-soft); border: 1px solid var(--border);
-  border-radius: 6px; padding: 0.5rem 0.6rem; display: block;
+  font-size: var(--t-xs); overflow-wrap: anywhere; color: var(--fg-muted);
+  background: var(--paper); border: 1px solid var(--line);
+  border-radius: var(--radius-sm); padding: var(--s-3); display: block; line-height: 1.5;
 }
-.pix-copy .btn { align-self: flex-start; }
 
-/* CTA final — painel destacado, centralizado */
+/* ------------------------------ CTA final --------------------------------
+   Fecha na cor da marca, ecoando o hero. Sem gradiente radial decorativo. */
 .cta-final { text-align: center; }
-.cta-final-inner {
-  position: relative; overflow: hidden;
-  padding: 3.5rem 1.75rem; border-radius: var(--radius-lg);
-  border: 1px solid var(--border); background: var(--bg-soft);
-}
-.cta-final-inner::before {
-  content: ""; position: absolute; inset: 0; pointer-events: none;
-  background: radial-gradient(60rem 22rem at 50% -30%, var(--brand-soft), transparent 70%);
-}
-.cta-final-inner > * { position: relative; }
-.cta-final h2 { margin-top: 0; }
-.cta-final .lead { margin-inline: auto; }
-.cta-final .cta-row { justify-content: center; margin-top: 1.75rem; }
+.cta-final h2 { margin: 0 auto var(--s-4); font-size: var(--t-2xl); max-width: 20ch; }
+.cta-final .lead { margin-inline: auto; color: color-mix(in oklab, var(--band-ink) 82%, transparent); }
+.cta-final .cta-row { justify-content: center; margin-top: var(--s-6); }
 
 /* ------------------------------ Rodapé ----------------------------------- */
 .site-footer { border-top: 1px solid var(--border); background: var(--bg); color: var(--fg-muted); }
@@ -456,8 +684,8 @@ input[type="password"]::-ms-clear { display: none; }
   display: grid; gap: 2rem;
   grid-template-columns: minmax(0, 1.4fr) repeat(3, minmax(0, 1fr));
 }
-@media (max-width: 820px) { .footer-grid { grid-template-columns: 1fr 1fr; } }
-@media (max-width: 480px) { .footer-grid { grid-template-columns: 1fr; } }
+@media (max-width: 820px) { .footer-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 480px) { .footer-grid { grid-template-columns: minmax(0, 1fr); } }
 .footer-title { font-weight: 700; color: var(--fg); margin: 0 0 0.5rem; }
 .footer-links { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.4rem; }
 .footer-links a { color: var(--fg-muted); }
@@ -583,9 +811,13 @@ input[type="password"]::-ms-clear { display: none; }
 .onb-bar {
   height: 0.4rem; border-radius: 999px; background: var(--border); overflow: hidden;
 }
+/* Progresso por transform: animar width causa layout thrash a cada passo do
+   wizard. A largura fica em 100% e o preenchimento é escalado no eixo X. */
 .onb-bar-fill {
-  display: block; height: 100%; border-radius: inherit; background: var(--brand);
-  transition: width 0.25s ease-out;
+  display: block; height: 100%; width: 100%; border-radius: inherit;
+  background: var(--brand); transform-origin: left center;
+  transform: scaleX(var(--onb-progress, 0));
+  transition: transform var(--dur) var(--ease-out);
 }
 .onb-card {
   padding: 1.75rem 1.5rem; box-shadow: var(--shadow);
@@ -652,14 +884,15 @@ input[type="password"]::-ms-clear { display: none; }
   text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-muted);
 }
 .docs-nav-title:first-child { margin-top: 0; }
+/* Item ativo por peso e fundo, não por tarja lateral colorida (banida). */
 .docs-nav a {
-  display: block; padding: 0.4rem 0.7rem; border-radius: 8px;
-  color: var(--fg-muted); font-size: 0.95rem; border-left: 2px solid transparent;
+  display: block; padding: 0.4rem 0.7rem; border-radius: var(--radius-sm);
+  color: var(--fg-muted); font-size: 0.95rem;
 }
-.docs-nav a:hover { color: var(--brand); background: var(--bg-soft); text-decoration: none; }
+.docs-nav a:hover { color: var(--brand); background: var(--surface); text-decoration: none; }
 .docs-nav a:target,
 .docs-nav a.is-active {
-  color: var(--brand); background: var(--brand-soft); border-left-color: var(--brand);
+  color: var(--brand); background: var(--brand-wash); font-weight: 600;
 }
 .docs-nav-ext { color: var(--brand) !important; font-weight: 500; }
 
@@ -674,7 +907,7 @@ input[type="password"]::-ms-clear { display: none; }
 .docs-content table { margin: 1.25rem 0; font-size: 0.95rem; }
 
 @media (max-width: 860px) {
-  .docs-layout { grid-template-columns: 1fr; gap: 1rem; }
+  .docs-layout { grid-template-columns: minmax(0, 1fr); gap: 1rem; }
   .docs-sidebar {
     position: static; border-bottom: 1px solid var(--border);
     padding-bottom: 1rem; margin-bottom: 1rem;
@@ -697,7 +930,7 @@ input[type="password"]::-ms-clear { display: none; }
     display: none; position: absolute; top: calc(100% + 1px); left: 0; right: 0;
     flex-direction: column; align-items: stretch; gap: 0.15rem;
     padding: 0.75rem 1.25rem 1rem; background: var(--bg);
-    border-bottom: 1px solid var(--border); box-shadow: var(--shadow); z-index: 60;
+    border-bottom: 1px solid var(--border); box-shadow: var(--shadow); z-index: var(--z-nav);
   }
   html.js .nav-links.is-open { display: flex; }
   html.js .nav-links a {
@@ -714,7 +947,10 @@ input[type="password"]::-ms-clear { display: none; }
   .section { padding: 2rem 0; }
   .hero { padding: 2.5rem 0 2rem; }
   .lead { font-size: 1.1rem; }
-  .cta-row .btn { width: 100%; }
+  /* Botões empilhados com a mesma largura: larguras diferentes no empilhamento
+     lêem como desalinho, não como hierarquia. */
+  .cta-row .btn, .hero-actions .btn { width: 100%; }
+  .hero-actions { gap: var(--s-2); }
   .page-header { align-items: flex-start; }
 }
 
@@ -933,7 +1169,7 @@ rect.cost-seg-outros, .dot.cost-seg-outros { fill: var(--cost-outros); backgroun
 
 /* Responsivo: sidebar vira barra rolável no topo */
 @media (max-width: 900px) {
-  .dash-shell { grid-template-columns: 1fr; gap: 1.25rem; }
+  .dash-shell { grid-template-columns: minmax(0, 1fr); gap: 1.25rem; }
   .dash-side { position: static; }
   .dash-nav { flex-direction: row; overflow-x: auto; gap: 0.35rem; padding-bottom: 0.25rem; }
   .dash-nav-item { flex: none; }
@@ -956,36 +1192,33 @@ rect.cost-seg-outros, .dot.cost-seg-outros { fill: var(--cost-outros); backgroun
 /* ---- Celular grande / tablet estreito (≤ 640px) ---- */
 @media (max-width: 640px) {
   /* Ritmo vertical mais próximo, com respiro consistente. */
-  .section { padding: 3rem 0; }
-  h2 { margin: 1.75rem 0 0.75rem; }
+  .section, .band { padding: var(--s-7) 0; }
+  h2 { margin: var(--s-5) 0 var(--s-3); }
 
-  /* Hero: título e lead ancorados; a janela de código empilha abaixo do texto. */
-  .hero { padding: 2.75rem 0 2.25rem; }
-  .hero-grid { gap: 2rem; }
-  .hero .lead { font-size: 1.15rem; }
+  /* Hero: o título domina a dobra; o registro empilha abaixo. */
+  .hero { padding: var(--s-7) 0 var(--s-7); }
+  .hero h1 { max-width: 100%; }
+  .hero-lead { font-size: var(--t-md); }
 
-  /* Janela de código: cabe na largura; rola só dentro de si mesma, nunca a página. */
-  .code-window { font-size: 0.82rem; border-radius: var(--radius); }
-  .code-window pre { padding: 0.9rem 1rem; }
+  /* Registro: cabe na largura e rola dentro de si, nunca a página. */
+  .record pre { padding: var(--s-3); font-size: var(--t-xs); }
 
-  /* Faixa de números: 2×2 equilibrado em vez de auto-fit desalinhado. */
-  .stat-grid { grid-template-columns: repeat(2, 1fr); gap: 1.5rem 1rem; padding: 2rem 1.25rem; }
-  .stat strong { font-size: 2rem; }
-
-  /* Cartões da landing: 1 coluna com toque confortável (portal fica intacto). */
-  .uc-card, .step, .sponsor-card { padding: 1.25rem; }
+  /* Cobertura: a barra fica mais alta para os rótulos caberem no toque. */
+  .cov-bar { height: 2.75rem; }
+  .cov-legend { gap: var(--s-2) var(--s-5); }
 
   /* Transparência: painéis coesos e filtros com alvo de toque cheio. */
-  .transparency-board { gap: 1rem; }
+  .transparency-board { gap: var(--s-4); }
   .chart-filter { min-height: 44px; padding: 0.5rem 0.9rem; }
   .chart-data summary { min-height: 44px; }
 }
 
 /* ---- Celular (≤ 480px) ---- */
 @media (max-width: 480px) {
-  .section { padding: 2.5rem 0; }
-  .stat-grid { gap: 1.25rem 0.75rem; }
-  .stat strong { font-size: 1.85rem; }
+  .section, .band { padding: var(--s-6) 0; }
+  /* Nos segmentos estreitos o número não cabe; a legenda abaixo carrega o
+     dado, então some com o rótulo interno em vez de deixá-lo cortado. */
+  .cov-seg { font-size: 0; }
 
   /* Gráficos de transparência: no viewBox 840×260, encolher para ~320px deixaria
      os rótulos dos eixos ilegíveis (~4px). A rolagem horizontal com min-width
@@ -999,12 +1232,39 @@ rect.cost-seg-outros, .dot.cost-seg-outros { fill: var(--cost-outros); backgroun
   .tp-stats { gap: 1rem 1.25rem; }
 
   /* Apoio: botões (Sponsors, repositório, copiar Pix) como alvos cheios. */
-  .sponsor-card .btn, .pix-copy .btn { align-self: stretch; }
+  .support-way .btn, .pix-copy .btn { justify-self: stretch; width: 100%; }
+  .pix-panel { justify-items: stretch; }
 }
 
 /* ---- Celular compacto (≤ 380px) ---- */
 @media (max-width: 380px) {
-  .stat strong { font-size: 1.65rem; }
-  .transparency-panel { padding: 1.1rem; }
-  .code-window { font-size: 0.78rem; }
+  .cov-total { font-size: var(--t-2xl); }
+  .transparency-panel { padding: var(--s-4); }
+  .record pre { font-size: 0.72rem; }
+}
+
+/* =========================================================================
+   Movimento. Uma entrada orquestrada no hero, e nada mais — o reflexo de
+   aplicar o mesmo fade-on-scroll em toda seção é justamente o tell que o
+   skill aponta. O conteúdo já nasce visível: a animação realça um estado
+   padrão legível em vez de destravá-lo, então nada some se o JS não rodar
+   ou se a aba estiver oculta durante a renderização.
+   ========================================================================= */
+/* Só transform, nunca opacidade a partir de zero. Com opacity:0 + delay o
+   conteúdo fica invisível até a animação disparar, e transição não roda em
+   aba oculta nem em renderizador headless — o hero sairia em branco numa
+   captura ou num snapshot de SEO. Assim o texto já nasce legível e o
+   movimento apenas o acomoda. */
+@media (prefers-reduced-motion: no-preference) {
+  .hero h1, .hero-lead, .hero-actions, .hero-note, .record {
+    animation: settle var(--dur-slow) var(--ease-out-soft) both;
+  }
+  .hero-lead { animation-delay: 0.06s; }
+  .hero-actions { animation-delay: 0.12s; }
+  .hero-note { animation-delay: 0.16s; }
+  .record { animation-delay: 0.09s; }
+}
+@keyframes settle {
+  from { transform: translateY(0.6rem); }
+  to { transform: none; }
 }

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}BNCC API — toda a Base Nacional Comum Curricular em uma API gratuita{% endblock %}</title>
-  <meta name="description" content="{% block description %}API pública e gratuita com toda a Base Nacional Comum Curricular (BNCC) do Brasil: 1.703 habilidades das três etapas, busca semântica com IA e API keys self-service.{% endblock %}">
+  <meta name="description" content="{% block description %}API pública e gratuita com toda a Base Nacional Comum Curricular (BNCC) do Brasil: 1.717 habilidades das três etapas, busca semântica com IA e API keys self-service.{% endblock %}">
   {% block robots %}{% endblock %}
   <link rel="canonical" href="{{ site_url }}{{ current_path }}">
   <link rel="icon" href="/favicon.ico" sizes="32x32">

--- a/app/web/templates/landing.html
+++ b/app/web/templates/landing.html
@@ -2,12 +2,12 @@
 
 {% block title %}BNCC API — toda a Base Nacional Comum Curricular em uma API gratuita{% endblock %}
 
-{% block description %}1.703 habilidades da BNCC — Educação Infantil, Fundamental e Médio, com o Complemento de
+{% block description %}1.717 habilidades da BNCC — Educação Infantil, Fundamental e Médio, com o Complemento de
 Computação — em uma API REST gratuita. Códigos e textos oficiais preservados, busca semântica com IA e
 API keys self-service.{% endblock %}
 
 {% block og_title %}BNCC API — toda a Base Nacional Comum Curricular em uma API gratuita{% endblock %}
-{% block og_description %}1.703 habilidades da BNCC (EI/EF/EM + Computação) com códigos oficiais preservados, busca semântica com IA e API keys self-service. Grátis e open-source.{% endblock %}
+{% block og_description %}1.717 habilidades da BNCC (EI/EF/EM + Computação) com códigos oficiais preservados, busca semântica com IA e API keys self-service. Grátis e open-source.{% endblock %}
 
 {% block head_extra %}
 <script type="application/ld+json">
@@ -65,7 +65,7 @@ API keys self-service.{% endblock %}
       "name": "A base de habilidades está completa?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Sim: 1.703 habilidades cobrindo Educação Infantil, Ensino Fundamental e Ensino Médio, incluindo as 140 do Complemento de Computação. O snapshot é versionado e a extração é determinística, reproduzível e auditada."
+        "text": "Sim: 1.717 habilidades cobrindo Educação Infantil, Ensino Fundamental e Ensino Médio, incluindo as 141 do Complemento de Computação. O snapshot é versionado e a extração é determinística, reproduzível e auditada."
       }
     },
     {
@@ -82,27 +82,29 @@ API keys self-service.{% endblock %}
 {% endblock %}
 
 {% block content %}
-<!-- ============================== HERO ============================== -->
-<section class="hero container" aria-labelledby="hero-heading">
-  <div class="hero-grid">
+<!-- ============================== HERO ==============================
+     Banda drenched na cor da marca. Uma ideia por dobra: a afirmação e a
+     resposta real que a sustenta. -->
+<section class="band band-brand hero" aria-labelledby="hero-heading">
+  <div class="container hero-inner">
     <div>
-      <p class="eyebrow">Grátis · Open-source · Fiel ao documento oficial</p>
-      <h1 id="hero-heading">A BNCC inteira, em uma API.</h1>
-      <p class="lead">
-        1.703 habilidades das três etapas, com os códigos e textos oficiais
-        preservados. Crie a conta, gere a chave e faça a primeira chamada hoje.
+      <h1 id="hero-heading">A BNCC inteira, <em>palavra por palavra</em>.</h1>
+      <p class="hero-lead">
+        1.717 habilidades das três etapas, com o código e o texto do documento
+        oficial. Grátis, aberta e com as contas na mesa.
       </p>
-      <p class="cta-row">
+      <p class="hero-actions">
         <a class="btn btn-lg" href="/portal/signup">Criar minha chave grátis</a>
-        <a class="btn btn-secondary btn-lg" href="/guia">Ver a documentação</a>
+        <a class="btn btn-secondary btn-lg" href="/guia">Ler o guia</a>
       </p>
-      <p class="hero-note">Sem cartão. Sem fila de aprovação. A chave sai na hora.</p>
+      <p class="hero-note">Sem cartão e sem fila de aprovação. A chave sai na hora.</p>
     </div>
-    <div class="code-window" aria-label="Exemplo de resposta da API">
-      <div class="code-window-bar">
-        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-        <span class="code-window-title">GET /api/v1/habilidades/EF05MA07</span>
-      </div>
+
+    <figure class="record" aria-label="Exemplo de resposta da API">
+      <figcaption class="record-head">
+        <span><span class="record-verb">GET</span> /api/v1/habilidades/EF05MA07</span>
+        <span>200</span>
+      </figcaption>
       <pre><code>{
   <span class="tk">"codigo"</span>: <span class="tv">"EF05MA07"</span>,
   <span class="tk">"descricao"</span>: <span class="tv">"Resolver e elaborar problemas
@@ -113,451 +115,420 @@ API keys self-service.{% endblock %}
   <span class="tk">"componente"</span>: <span class="tv">"matematica"</span>,
   <span class="tk">"unidade_tematica"</span>: <span class="tv">"Números"</span>
 }</code></pre>
-    </div>
+    </figure>
   </div>
 </section>
 
-<!-- ========================= PROVA SOCIAL ========================== -->
-<section class="stat-strip" aria-label="Números do projeto">
-  <div class="container stat-grid">
-    <div class="stat"><strong>1.703</strong><span>habilidades oficiais</span></div>
-    <div class="stat"><strong>3</strong><span>etapas: EI · EF · EM</span></div>
-    <div class="stat"><strong>140</strong><span>habilidades de Computação</span></div>
-    <div class="stat"><strong>MIT</strong><span>open-source e gratuita</span></div>
+<!-- ========================= COBERTURA DA BASE =========================
+     Substitui a antiga faixa de quatro números soltos. As três etapas em
+     proporção real: "a base inteira" vira uma coisa que se vê. -->
+<section class="section container" aria-labelledby="cobertura-heading">
+  <h2 id="cobertura-heading">A base inteira, da creche ao terceiro ano</h2>
+  <div class="cov-head">
+    <p class="cov-total">1.717</p>
+    <p class="cov-total-label">habilidades catalogadas, nas três etapas</p>
   </div>
-</section>
 
-<!-- =========================== PROBLEMA ============================ -->
-<section class="section container section-narrow" aria-labelledby="problema-heading">
-  <h2 id="problema-heading">Seu produto fala de educação. Ele fala BNCC?</h2>
-  <p class="lead">
-    Modelos de IA inventam códigos de habilidade. PDFs oficiais não foram feitos para
-    máquinas. Planilhas montadas à mão envelhecem sozinhas. A BNCC API entrega a camada
-    de dados pronta — você cuida do produto.
+  <div class="cov-bar" role="img"
+       aria-label="Distribuição das 1.717 habilidades: Educação Infantil 104, Ensino Fundamental 1.408, Ensino Médio 205.">
+    <span class="cov-seg cov-seg-ei" style="flex: 104"></span>
+    <span class="cov-seg cov-seg-ef" style="flex: 1408">1.408</span>
+    <span class="cov-seg cov-seg-em" style="flex: 205">205</span>
+  </div>
+
+  <ul class="cov-legend">
+    <li><span class="swatch cov-seg-ei"></span><b>104</b> <span>Educação Infantil</span></li>
+    <li><span class="swatch cov-seg-ef"></span><b>1.408</b> <span>Ensino Fundamental</span></li>
+    <li><span class="swatch cov-seg-em"></span><b>205</b> <span>Ensino Médio</span></li>
+  </ul>
+
+  <p class="cov-note">
+    Inclui as 141 habilidades do Complemento de Computação, que passa a ser
+    obrigatório em 2026, com os eixos de Educação Infantil e Fundamental já
+    estruturados. Os números vêm do snapshot versionado: quando a base muda,
+    este parágrafo muda junto.
   </p>
 </section>
 
-<!-- ========================= CASOS DE USO ========================== -->
-<section class="section container" id="casos-de-uso" aria-labelledby="casos-heading">
-  <h2 id="casos-heading">O que dá para construir</h2>
-  <p class="lead">Cinco usos ancorados em problemas reais das escolas e redes do Brasil.</p>
-  <div class="grid uc-grid">
-
-    <article class="card uc-card">
-      <span class="uc-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <path
-            d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
-          <path d="m9 12 2 2 4-4" />
-        </svg>
-      </span>
-      <h3>Planos de aula com IA que não erra o código</h3>
-      <p class="muted">
-        Modelos genéricos alucinam códigos BNCC. Valide cada um de forma determinística e
-        ancore a geração em fontes oficiais rastreáveis.
+<!-- ====================== FIDELIDADE / COMO SE PROVA ======================
+     O argumento mais forte do projeto, que na versão anterior estava
+     escondido dentro de um cartão chamado "Determinística e versionada". -->
+<section class="section band-surface" aria-labelledby="fidelidade-heading">
+  <div class="container proof-grid">
+    <div>
+      <h2 id="fidelidade-heading">Como você sabe que o texto está certo</h2>
+      <p class="lead">
+        Porque dá para conferir. Modelos de linguagem inventam código de
+        habilidade com uma confiança desconfortável, e planilha montada à mão
+        envelhece sozinha. A extração aqui é auditada, e a auditoria é pública.
       </p>
-      <p><code class="endpoint">GET /habilidades/{codigo}</code> <code class="endpoint">POST /busca-semantica</code></p>
-    </article>
+    </div>
 
-    <article class="card uc-card">
-      <span class="uc-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <circle cx="6" cy="19" r="3" />
-          <path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15" />
-          <circle cx="18" cy="5" r="3" />
-        </svg>
-      </span>
-      <h3>Trilhas de recomposição de aprendizagens</h3>
-      <p class="muted">
-        Navegue as relações entre habilidades e monte trilhas por ano e componente.
-        Progressão por turma guiada pelo dado, não pela intuição.
-      </p>
-      <p><code class="endpoint">GET /habilidades/{codigo}/relacoes</code></p>
-    </article>
-
-    <article class="card uc-card">
-      <span class="uc-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <rect x="4" y="4" width="16" height="16" rx="2" />
-          <rect x="9" y="9" width="6" height="6" />
-          <path d="M9 1v3M15 1v3M9 20v3M15 20v3M1 9h3M1 15h3M20 9h3M20 15h3" />
-        </svg>
-      </span>
-      <h3>Adequação à BNCC Computação</h3>
-      <p class="muted">
-        O Complemento de Computação passa a ser obrigatório em 2026. As 140 habilidades,
-        com eixos estruturados, prontas para cruzar com o currículo da sua rede.
-      </p>
-      <p><code class="endpoint">GET /habilidades?componente=computacao&amp;eixo=…</code></p>
-    </article>
-
-    <article class="card uc-card">
-      <span class="uc-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <path d="M3 3v16a2 2 0 0 0 2 2h16" />
-          <rect x="7" y="8" width="3" height="8" />
-          <rect x="12" y="5" width="3" height="11" />
-          <rect x="17" y="11" width="3" height="5" />
-        </svg>
-      </span>
-      <h3>Cobertura curricular à vista do gestor</h3>
-      <p class="muted">
-        Lacunas de currículo costumam aparecer só no SAEB, tarde demais. Cruze os
-        planejamentos com a taxonomia oficial e veja a cobertura por ano, componente e
-        bimestre — a tempo de agir.
-      </p>
-      <p><code class="endpoint">GET /taxonomia</code> <code class="endpoint">POST /busca-semantica</code></p>
-    </article>
-
-    <article class="card uc-card">
-      <span class="uc-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <path
-            d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z" />
-          <circle cx="7.5" cy="7.5" r="1" />
-        </svg>
-      </span>
-      <h3>Conteúdo etiquetado por habilidade</h3>
-      <p class="muted">
-        Catalogar milhares de vídeos e atividades à mão não escala. A busca semântica
-        sugere os códigos e o especialista só confirma.
-      </p>
-      <p><code class="endpoint">POST /busca-semantica</code></p>
-    </article>
-
-    <article class="card uc-card uc-card-cta">
-      <h3>Outro caso em mente?</h3>
-      <p class="muted">
-        A API é gratuita e o contrato é estável e versionado. Comece pelo guia e construa
-        sobre dados confiáveis.
-      </p>
-      <p><a class="btn btn-secondary" href="/guia">Ler o guia de início rápido</a></p>
-    </article>
+    <ul class="proof-list">
+      <li>
+        <dfn>Extração determinística</dfn>
+        <p>
+          O snapshot sai dos PDFs oficiais por script versionado. Rodar de novo
+          produz exatamente o mesmo arquivo.
+        </p>
+      </li>
+      <li>
+        <dfn>Conferido contra duas testemunhas independentes</dfn>
+        <p>
+          As descrições foram cruzadas com o documento oficial completo e com um
+          dataset independente da versão homologada. Isso corrigiu
+          <span class="proof-figure">59</span> descrições que a extração havia
+          embaralhado entre colunas do PDF, e recuperou uma habilidade que
+          faltava, a EF05CO11.
+        </p>
+      </li>
+      <li>
+        <dfn>Auditoria no portão de teste</dfn>
+        <p>
+          Um script versionado procura truncamento, contaminação entre células e
+          fusão de texto a cada mudança. Hoje ele fecha com
+          <span class="proof-figure">0</span> achados de erro, e o teste quebra
+          se isso deixar de ser verdade.
+        </p>
+      </li>
+      <li>
+        <dfn>O que a IA escreve vem etiquetado</dfn>
+        <p>
+          A busca semântica devolve as fontes oficiais junto com a resposta, e
+          todo texto gerado sai marcado como não-oficial. Se a camada de IA cair,
+          consulta por código, filtros, relações e taxonomia seguem de pé.
+        </p>
+      </li>
+    </ul>
   </div>
 </section>
 
-<!-- ========================= COMO FUNCIONA ========================= -->
+<!-- ========================= DA CONTA À CHAMADA ========================= -->
 <section class="section container" aria-labelledby="como-heading">
-  <h2 id="como-heading">Da conta à primeira chamada em 3 passos</h2>
-  <div class="grid steps-grid">
-    <article class="card step">
-      <span class="step-num" aria-hidden="true">1</span>
+  <h2 id="como-heading">Da conta à primeira chamada</h2>
+  <ol class="steps">
+    <li class="step">
       <h3>Crie a conta</h3>
-      <p class="muted">E-mail e senha, verificação e pronto. Sem aprovação manual, sem cartão.</p>
-    </article>
-    <article class="card step">
-      <span class="step-num" aria-hidden="true">2</span>
+      <p>E-mail e senha, verificação, pronto. Sem aprovação manual e sem cartão.</p>
+    </li>
+    <li class="step">
       <h3>Gere a chave</h3>
-      <p class="muted">Crie e revogue API keys quando quiser, direto no portal, e acompanhe o uso.</p>
-    </article>
-    <article class="card step">
-      <span class="step-num" aria-hidden="true">3</span>
+      <p>Crie e revogue API keys quando quiser, no portal, acompanhando o uso.</p>
+    </li>
+    <li class="step">
       <h3>Chame a API</h3>
-      <p class="muted">Endpoints REST sob <code>/api/v1</code>, documentados no OpenAPI.</p>
-    </article>
-  </div>
+      <p>Endpoints REST sob <code>/api/v1</code>, documentados no OpenAPI.</p>
+    </li>
+  </ol>
   <pre class="curl-block"><code>curl -H <span class="tv">"Authorization: Bearer SUA_API_KEY"</span> \
   "{{ (request.base_url|string).rstrip('/') }}/api/v1/habilidades?etapa=ensino_fundamental&amp;ano=5"</code></pre>
 </section>
 
-<!-- =========================== RECURSOS ============================ -->
-<section class="section container" aria-labelledby="recursos-heading">
-  <h2 id="recursos-heading">Feita para levar dado educacional a sério</h2>
-  <div class="grid">
-    <article class="card">
-      <h3>Determinística e versionada</h3>
-      <p class="muted">
-        As três etapas extraídas das fontes oficiais de forma reproduzível, com relações
-        navegáveis entre habilidades, competências e objetos de conhecimento. O contrato
-        é versionado: nada quebra dentro do <code>/api/v1</code>.
+<!-- ============================ CASOS DE USO ============================
+     Lista com hierarquia em vez de grid de cartões idênticos. O endpoint é
+     a âncora visual de cada item. -->
+<section class="section container" id="casos-de-uso" aria-labelledby="casos-heading">
+  <h2 id="casos-heading">O que dá para construir</h2>
+  <p class="lead">Cinco usos ancorados em problemas reais das escolas e redes do Brasil.</p>
+
+  <ul class="uc-list">
+    <li class="uc-item uc-lead">
+      <p class="uc-endpoints">
+        <code class="endpoint">GET /habilidades/{codigo}</code>
+        <code class="endpoint">POST /busca-semantica</code>
       </p>
-    </article>
-    <article class="card">
-      <h3>Self-service de verdade</h3>
-      <p class="muted">
-        Você cria e revoga as chaves no portal e acompanha o consumo em um painel. Cota
-        clara: 60 requisições por minuto nos endpoints determinísticos.
+      <div class="uc-body">
+        <h3>Planos de aula com IA que não erra o código</h3>
+        <p>
+          Um modelo genérico alucina códigos da BNCC e o professor só descobre
+          depois. Valide cada código de forma determinística e ancore a geração
+          em fontes oficiais rastreáveis.
+        </p>
+      </div>
+    </li>
+
+    <li class="uc-item">
+      <p class="uc-endpoints"><code class="endpoint">GET /habilidades/{codigo}/relacoes</code></p>
+      <div class="uc-body">
+        <h3>Trilhas de recomposição de aprendizagens</h3>
+        <p>
+          Navegue as relações entre habilidades e monte trilhas por ano e
+          componente, com a progressão da turma guiada pelo dado.
+        </p>
+      </div>
+    </li>
+
+    <li class="uc-item">
+      <p class="uc-endpoints"><code class="endpoint">GET /habilidades?componente=computacao</code></p>
+      <div class="uc-body">
+        <h3>Adequação à BNCC Computação</h3>
+        <p>
+          O Complemento de Computação passa a valer em 2026. As 141 habilidades,
+          com eixos estruturados, prontas para cruzar com o currículo da sua rede.
+        </p>
+      </div>
+    </li>
+
+    <li class="uc-item">
+      <p class="uc-endpoints">
+        <code class="endpoint">GET /taxonomia</code>
+        <code class="endpoint">POST /busca-semantica</code>
       </p>
-    </article>
-    <article class="card">
-      <h3>Documentação sempre em dia</h3>
-      <p class="muted">
-        Docs geradas do contrato OpenAPI: schemas, exemplos e teste autenticado no
-        navegador, sincronizados com o código.
-      </p>
-    </article>
-    <article class="card">
-      <h3>Busca semântica com IA <span class="badge badge-muted">não-oficial</span></h3>
-      <p class="muted">
-        Pergunte em linguagem natural e receba respostas com fontes oficiais rastreáveis.
-        Todo conteúdo gerado é marcado como não-oficial; os dados determinísticos seguem
-        sendo a fonte da verdade, mesmo se a IA cair.
-      </p>
-    </article>
-  </div>
+      <div class="uc-body">
+        <h3>Cobertura curricular à vista do gestor</h3>
+        <p>
+          Lacuna de currículo costuma aparecer no SAEB, tarde demais. Cruze os
+          planejamentos com a taxonomia oficial e veja a cobertura por ano,
+          componente e bimestre a tempo de agir.
+        </p>
+      </div>
+    </li>
+
+    <li class="uc-item">
+      <p class="uc-endpoints"><code class="endpoint">POST /busca-semantica</code></p>
+      <div class="uc-body">
+        <h3>Conteúdo etiquetado por habilidade</h3>
+        <p>
+          Catalogar milhares de vídeos e atividades à mão não escala. A busca
+          semântica sugere os códigos e o especialista confirma.
+        </p>
+      </div>
+    </li>
+  </ul>
 </section>
 
-<!-- ======================== APOIE O PROJETO ======================== -->
-<section class="section sponsor-section" id="apoie" aria-labelledby="apoie-heading">
+<!-- =========================== AS CONTAS ABERTAS ===========================
+     Transparência e apoio na mesma seção: separados, viravam dois argumentos
+     pela metade. Juntos sustentam "é grátis de verdade" e "não vai sumir". -->
+<section class="section band-surface" id="apoie" aria-labelledby="contas-heading">
   <div class="container">
-    <h2 id="apoie-heading">Grátis hoje. Sustentada por quem usa.</h2>
-    <p class="lead">
-      A API roda em infraestrutura real (Cloud Run + Postgres) e é mantida nas horas
-      livres. Se ela poupou seu tempo ou entrou no que você construiu, considere apoiar —
-      qualquer valor mantém tudo no ar.
+    <h2 id="contas-heading">As contas abertas</h2>
+
+  {% if (usage_summary and usage_summary.has_data) or (cost_chart and cost_chart.has_data) %}
+    <p class="lead transparency-lead">
+      Quanto a plataforma é usada e quanto custa mantê-la no ar. Números
+      agregados, sem login, atualizados a cada 10 minutos.
     </p>
-    <div class="grid sponsor-grid">
-      <article class="card sponsor-card">
-        <span class="uc-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round">
-            <path
-              d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7z" />
-          </svg>
-        </span>
-        <h3>GitHub Sponsors</h3>
-        <p class="muted">Apoio avulso ou mensal no cartão internacional, sem taxa de plataforma.</p>
-        <p><a class="btn" href="https://github.com/sponsors/eumakerdev" rel="noopener">Apoiar no GitHub Sponsors</a></p>
-      </article>
-      <article class="card sponsor-card">
-        <span class="uc-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round">
-            <rect x="3" y="3" width="7" height="7" rx="1" />
-            <rect x="14" y="3" width="7" height="7" rx="1" />
-            <rect x="3" y="14" width="7" height="7" rx="1" />
-            <path d="M14 14h3v3h-3zM18 18h3v3h-3z" />
-          </svg>
-        </span>
-        <h3>Pix</h3>
-        <p class="muted">Aponte a câmera para o QR Code ou copie o código e cole em Pix › Copia e Cola. Você escolhe o
-          valor.</p>
-        <img class="pix-qr" src="/static/pix-qrcode.png" alt="QR Code Pix para apoiar o projeto" width="140"
-          height="140" loading="lazy">
-        <div class="pix-copy">
-          <code
-            id="pix-code">00020126360014BR.GOV.BCB.PIX0114+55719990084435204000053039865802BR5913FABIO SANTANA6006BRASIL62110507BNCCAPI63040E12</code>
-          <button type="button" class="btn btn-secondary btn-sm" id="pix-copy-btn" aria-label="Copiar código Pix">Copiar
-            código Pix</button>
+    <div class="transparency-board" id="transparencia">
+
+    {% if usage_summary and usage_summary.has_data %}
+      <article class="transparency-panel usage-block">
+        <header class="tp-head">
+          <p class="tp-overline">Uso da plataforma</p>
+          <p class="tp-hero">
+            <span class="tp-value">{{ usage_summary.total_to_date|milhar }}</span>
+            <span class="tp-unit">requisições atendidas</span>
+          </p>
+          <p class="tp-since">
+            {% if usage_summary.period_start %}desde {{ usage_summary.period_start.strftime('%m/%Y') }} · {% endif %}só o total — nada por usuário, chave ou IP
+          </p>
+        </header>
+
+        <dl class="tp-stats">
+          <div class="tp-stat">
+            <dt>Desenvolvedores</dt>
+            <dd>{{ usage_summary.developers|milhar }}</dd>
+          </div>
+          <div class="tp-stat">
+            <dt>Chaves ativas</dt>
+            <dd>{{ usage_summary.active_keys|milhar }}</dd>
+          </div>
+        </dl>
+
+        <div class="tp-chart">
+          <div class="tp-chart-head">
+            <p class="tp-chart-title">Requisições por dia</p>
+            <div class="chart-filters" role="group" aria-label="Período do gráfico">
+              {% for w in usage_summary.windows %}
+              <button type="button" class="chart-filter{% if w.days == usage_summary.default_window %} is-active{% endif %}"
+                      data-window-btn="{{ w.days }}"
+                      aria-pressed="{{ 'true' if w.days == usage_summary.default_window else 'false' }}">
+                {{ w.days }}d
+              </button>
+              {% endfor %}
+            </div>
+          </div>
+
+          {% for w in usage_summary.windows %}
+          {% set chart = usage_charts[w.days] %}
+          <div class="usage-window" data-window="{{ w.days }}"{% if w.days != usage_summary.default_window %} hidden{% endif %}>
+            <div class="chart-scroll">
+            <svg class="usage-chart" viewBox="0 0 {{ chart.width }} {{ chart.height }}"
+                 role="img" preserveAspectRatio="none"
+                 aria-label="Requisições por dia nos últimos {{ w.days }} dias. Total de {{ w.total_requests|milhar }} requisições, média de {{ w.daily_average|milhar }} por dia.">
+              {% for t in chart.y_ticks %}
+              <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ chart.width - 12 }}" y2="{{ t.pos }}"/>
+              <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
+              {% endfor %}
+              <path class="chart-area chart-area-total" d="{{ chart.area }}"/>
+              <polyline class="chart-line chart-line-total" points="{{ chart.line }}"/>
+              {% for t in chart.x_ticks %}
+              <text class="chart-axis" x="{{ t.pos }}" y="{{ chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
+              {% endfor %}
+            </svg>
+            </div>
+            <p class="tp-chart-foot">
+              <strong>{{ w.total_requests|milhar }}</strong> em {{ w.days }} dias · <strong>{{ w.daily_average|milhar }}</strong>/dia em média
+            </p>
+          </div>
+          {% endfor %}
+
+          {% set dw = usage_summary.windows | selectattr('days', 'equalto', usage_summary.default_window) | first %}
+          {% if dw %}
+          <details class="chart-data">
+            <summary>Ver dados em tabela ({{ dw.days }} dias)</summary>
+            <div class="table-wrap">
+              <table>
+                <thead><tr><th scope="col">Dia</th><th scope="col">Requisições</th></tr></thead>
+                <tbody>
+                  {% for p in dw.series %}
+                  <tr><td data-label="Dia">{{ p.date.strftime('%d/%m') }}</td><td data-label="Requisições">{{ p.total|milhar }}</td></tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </details>
+          {% endif %}
         </div>
       </article>
-      <article class="card sponsor-card">
-        <span class="uc-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round">
-            <path
-              d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.12 2.12 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.12 2.12 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.12 2.12 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.12 2.12 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.12 2.12 0 0 0 1.597-1.16z" />
+    {% endif %}
+
+    {% if cost_chart and cost_chart.has_data %}
+      <article class="transparency-panel cost-block">
+        <header class="tp-head">
+          <p class="tp-overline">Custo de infraestrutura</p>
+          <p class="tp-hero">
+            <span class="tp-value">{{ cost_summary.total_to_date|brl }}</span>
+            <span class="tp-unit">até agora</span>
+          </p>
+          <p class="tp-since">
+            {% if cost_summary and cost_summary.period_start %}desde {{ cost_summary.period_start.strftime('%m/%Y') }} · {% endif %}{{ cost_summary.total_month|brl }} neste mês
+          </p>
+        </header>
+
+        <dl class="tp-stats tp-breakdown">
+          {% for item in cost_summary.by_service_to_date %}
+          {% if item.amount > 0 %}
+          <div class="tp-stat">
+            <dt><span class="dot cost-seg-{{ item.service.value }}"></span>{{ item.label }}</dt>
+            <dd>{{ item.amount|brl }}</dd>
+          </div>
+          {% endif %}
+          {% endfor %}
+        </dl>
+
+        <div class="tp-chart">
+          <div class="tp-chart-head">
+            <p class="tp-chart-title">Custo por mês</p>
+            <p class="tp-chart-caption muted">por serviço, em R$</p>
+          </div>
+
+          <div class="chart-scroll">
+          <svg class="usage-chart cost-chart" viewBox="0 0 {{ cost_chart.width }} {{ cost_chart.height }}"
+               role="img" preserveAspectRatio="none"
+               aria-label="Custo mensal de infraestrutura por serviço, em reais. Total acumulado de {{ cost_summary.total_to_date|brl }}.">
+            {% for t in cost_chart.y_ticks %}
+            <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ cost_chart.width - 12 }}" y2="{{ t.pos }}"/>
+            <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
+            {% endfor %}
+            {% for bar in cost_chart.bars %}
+              {% for seg in bar.segments %}
+              <rect class="cost-bar {{ seg.color_class }}" x="{{ seg.x }}" y="{{ seg.y }}"
+                    width="{{ seg.width }}" height="{{ seg.height }}"><title>{{ seg.title }}</title></rect>
+              {% endfor %}
+            {% endfor %}
+            {% for t in cost_chart.x_ticks %}
+            <text class="chart-axis" x="{{ t.pos }}" y="{{ cost_chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
+            {% endfor %}
           </svg>
-        </span>
-        <h3>Uma estrela no GitHub</h3>
-        <p class="muted">Não custa nada e ajuda o projeto a chegar a mais gente que constrói educação no Brasil.
+          </div>
+
+          <details class="chart-data">
+            <summary>Ver dados em tabela</summary>
+            <div class="table-wrap">
+              <table>
+                <thead><tr><th scope="col">Mês</th><th scope="col">Total</th></tr></thead>
+                <tbody>
+                  {% for bar in cost_chart.bars %}
+                  <tr><td data-label="Mês">{{ bar.label }}</td><td data-label="Total">{{ bar.total|brl }}</td></tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        </div>
+
+        <p class="tp-source">
+          Faturamento real do Google Cloud, líquido de créditos. Custo de
+          <strong>infraestrutura</strong> — não é dado da BNCC.
         </p>
-        <p><a class="btn btn-secondary" href="https://github.com/eumakerdev/bncc_api" rel="noopener">Ver o
-            repositório</a></p>
       </article>
+    {% endif %}
+
+      <article class="transparency-panel funding-block">
+        <header class="tp-head">
+          <p class="tp-overline">Apoio financeiro recebido</p>
+          <p class="tp-hero">
+            <span class="tp-value">R$ 0</span>
+            <span class="tp-unit">até agora</span>
+          </p>
+          <p class="tp-since">nenhum patrocínio, edital ou doação registrado até hoje</p>
+        </header>
+        <p class="funding-note">
+          A infraestrutura que mantém a BNCC API no ar sai do bolso de quem cuida
+          do projeto. Quando chegar o primeiro apoio, esta seção passa a mostrar
+          quanto foi, de onde veio e no que foi aplicado, com a mesma auditoria
+          pública que já vale para os custos.
+        </p>
+      </article>
+
+    </div>
+  {% endif %}
+
+    <!-- ---------------------------- Apoie ---------------------------- -->
+    <div class="support-grid">
+      <div class="support-ways">
+        <h3 class="support-title">Se ela te poupou tempo, ajude a manter</h3>
+        <div class="support-way">
+          <h4>GitHub Sponsors</h4>
+          <p>Apoio avulso ou mensal no cartão internacional, sem taxa de plataforma.</p>
+          <a class="btn" href="https://github.com/sponsors/eumakerdev" rel="noopener">Apoiar no GitHub Sponsors</a>
+        </div>
+        <div class="support-way">
+          <h4>Uma estrela no repositório</h4>
+          <p>
+            Não custa nada e ajuda o projeto a chegar a mais gente que constrói
+            educação no Brasil.
+          </p>
+          <a class="btn btn-secondary" href="https://github.com/eumakerdev/bncc_api" rel="noopener">Ver o repositório</a>
+        </div>
+      </div>
+
+      <div class="pix-panel">
+        <h4>Pix</h4>
+        <p class="muted">
+          Aponte a câmera para o QR Code ou copie o código e cole em Pix ›
+          Copia e Cola. Você escolhe o valor.
+        </p>
+        <img class="pix-qr" src="/static/pix-qrcode.png" alt="QR Code Pix para apoiar o projeto"
+             width="140" height="140" loading="lazy">
+        <div class="pix-copy">
+          <code id="pix-code">00020126360014BR.GOV.BCB.PIX0114+55719990084435204000053039865802BR5913FABIO SANTANA6006BRASIL62110507BNCCAPI63040E12</code>
+          <button type="button" class="btn btn-secondary btn-sm" id="pix-copy-btn">Copiar código Pix</button>
+        </div>
+      </div>
     </div>
   </div>
 </section>
 
-<!-- ========================== TRANSPARÊNCIA ========================= -->
-{% if (usage_summary and usage_summary.has_data) or (cost_chart and cost_chart.has_data) %}
-<section class="section container" id="transparencia" aria-labelledby="transparencia-title">
-  <h2 id="transparencia-title">Transparência</h2>
-  <p class="lead transparency-lead">
-    O uso real da plataforma e quanto custa mantê-la no ar. Números agregados,
-    sem login, atualizados a cada 10 minutos.
-  </p>
-
-  <div class="transparency-board">
-
-  {% if usage_summary and usage_summary.has_data %}
-    <article class="transparency-panel usage-block">
-      <header class="tp-head">
-        <p class="tp-overline">Uso da plataforma</p>
-        <p class="tp-hero">
-          <span class="tp-value">{{ usage_summary.total_to_date|milhar }}</span>
-          <span class="tp-unit">requisições atendidas</span>
-        </p>
-        <p class="tp-since">
-          {% if usage_summary.period_start %}desde {{ usage_summary.period_start.strftime('%m/%Y') }} · {% endif %}só o total — nada por usuário, chave ou IP
-        </p>
-      </header>
-
-      <dl class="tp-stats">
-        <div class="tp-stat">
-          <dt>Desenvolvedores</dt>
-          <dd>{{ usage_summary.developers|milhar }}</dd>
-        </div>
-        <div class="tp-stat">
-          <dt>Chaves ativas</dt>
-          <dd>{{ usage_summary.active_keys|milhar }}</dd>
-        </div>
-      </dl>
-
-      <div class="tp-chart">
-        <div class="tp-chart-head">
-          <p class="tp-chart-title">Requisições por dia</p>
-          <div class="chart-filters" role="group" aria-label="Período do gráfico">
-            {% for w in usage_summary.windows %}
-            <button type="button" class="chart-filter{% if w.days == usage_summary.default_window %} is-active{% endif %}"
-                    data-window-btn="{{ w.days }}"
-                    aria-pressed="{{ 'true' if w.days == usage_summary.default_window else 'false' }}">
-              {{ w.days }}d
-            </button>
-            {% endfor %}
-          </div>
-        </div>
-
-        {% for w in usage_summary.windows %}
-        {% set chart = usage_charts[w.days] %}
-        <div class="usage-window" data-window="{{ w.days }}"{% if w.days != usage_summary.default_window %} hidden{% endif %}>
-          <div class="chart-scroll">
-          <svg class="usage-chart" viewBox="0 0 {{ chart.width }} {{ chart.height }}"
-               role="img" preserveAspectRatio="none"
-               aria-label="Requisições por dia nos últimos {{ w.days }} dias. Total de {{ w.total_requests|milhar }} requisições, média de {{ w.daily_average|milhar }} por dia.">
-            {% for t in chart.y_ticks %}
-            <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ chart.width - 12 }}" y2="{{ t.pos }}"/>
-            <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
-            {% endfor %}
-            <path class="chart-area chart-area-total" d="{{ chart.area }}"/>
-            <polyline class="chart-line chart-line-total" points="{{ chart.line }}"/>
-            {% for t in chart.x_ticks %}
-            <text class="chart-axis" x="{{ t.pos }}" y="{{ chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
-            {% endfor %}
-          </svg>
-          </div>
-          <p class="tp-chart-foot">
-            <strong>{{ w.total_requests|milhar }}</strong> em {{ w.days }} dias · <strong>{{ w.daily_average|milhar }}</strong>/dia em média
-          </p>
-        </div>
-        {% endfor %}
-
-        {% set dw = usage_summary.windows | selectattr('days', 'equalto', usage_summary.default_window) | first %}
-        {% if dw %}
-        <details class="chart-data">
-          <summary>Ver dados em tabela ({{ dw.days }} dias)</summary>
-          <div class="table-wrap">
-            <table>
-              <thead><tr><th scope="col">Dia</th><th scope="col">Requisições</th></tr></thead>
-              <tbody>
-                {% for p in dw.series %}
-                <tr><td data-label="Dia">{{ p.date.strftime('%d/%m') }}</td><td data-label="Requisições">{{ p.total|milhar }}</td></tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </details>
-        {% endif %}
-      </div>
-    </article>
-  {% endif %}
-
-  {% if cost_chart and cost_chart.has_data %}
-    <article class="transparency-panel cost-block">
-      <header class="tp-head">
-        <p class="tp-overline">Custo de infraestrutura</p>
-        <p class="tp-hero">
-          <span class="tp-value">{{ cost_summary.total_to_date|brl }}</span>
-          <span class="tp-unit">até agora</span>
-        </p>
-        <p class="tp-since">
-          {% if cost_summary and cost_summary.period_start %}desde {{ cost_summary.period_start.strftime('%m/%Y') }} · {% endif %}{{ cost_summary.total_month|brl }} neste mês
-        </p>
-      </header>
-
-      <dl class="tp-stats tp-breakdown">
-        {% for item in cost_summary.by_service_to_date %}
-        {% if item.amount > 0 %}
-        <div class="tp-stat">
-          <dt><span class="dot cost-seg-{{ item.service.value }}"></span>{{ item.label }}</dt>
-          <dd>{{ item.amount|brl }}</dd>
-        </div>
-        {% endif %}
-        {% endfor %}
-      </dl>
-
-      <div class="tp-chart">
-        <div class="tp-chart-head">
-          <p class="tp-chart-title">Custo por mês</p>
-          <p class="tp-chart-caption muted">por serviço, em R$</p>
-        </div>
-
-        <div class="chart-scroll">
-        <svg class="usage-chart cost-chart" viewBox="0 0 {{ cost_chart.width }} {{ cost_chart.height }}"
-             role="img" preserveAspectRatio="none"
-             aria-label="Custo mensal de infraestrutura por serviço, em reais. Total acumulado de {{ cost_summary.total_to_date|brl }}.">
-          {% for t in cost_chart.y_ticks %}
-          <line class="chart-grid" x1="44" y1="{{ t.pos }}" x2="{{ cost_chart.width - 12 }}" y2="{{ t.pos }}"/>
-          <text class="chart-axis" x="38" y="{{ t.pos + 4 }}" text-anchor="end">{{ t.label }}</text>
-          {% endfor %}
-          {% for bar in cost_chart.bars %}
-            {% for seg in bar.segments %}
-            <rect class="cost-bar {{ seg.color_class }}" x="{{ seg.x }}" y="{{ seg.y }}"
-                  width="{{ seg.width }}" height="{{ seg.height }}"><title>{{ seg.title }}</title></rect>
-            {% endfor %}
-          {% endfor %}
-          {% for t in cost_chart.x_ticks %}
-          <text class="chart-axis" x="{{ t.pos }}" y="{{ cost_chart.height - 8 }}" text-anchor="middle">{{ t.label }}</text>
-          {% endfor %}
-        </svg>
-        </div>
-
-        <details class="chart-data">
-          <summary>Ver dados em tabela</summary>
-          <div class="table-wrap">
-            <table>
-              <thead><tr><th scope="col">Mês</th><th scope="col">Total</th></tr></thead>
-              <tbody>
-                {% for bar in cost_chart.bars %}
-                <tr><td data-label="Mês">{{ bar.label }}</td><td data-label="Total">{{ bar.total|brl }}</td></tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </details>
-      </div>
-
-      <p class="tp-source">
-        Faturamento real do Google Cloud, líquido de créditos. Custo de
-        <strong>infraestrutura</strong> — não é dado da BNCC.
-      </p>
-    </article>
-  {% endif %}
-
-    <article class="transparency-panel funding-block">
-      <header class="tp-head">
-        <p class="tp-overline">Apoio financeiro recebido</p>
-        <p class="tp-hero">
-          <span class="tp-value">R$ 0</span>
-          <span class="tp-unit">até agora</span>
-        </p>
-        <p class="tp-since">nenhum patrocínio, edital ou doação registrado até hoje</p>
-      </header>
-      <p class="funding-note">
-        A infraestrutura que mantém a BNCC API no ar sai do bolso de quem cuida do
-        projeto. Quando chegar o primeiro apoio, esta seção passa a mostrar quanto
-        foi, de onde veio e no que foi aplicado — a mesma auditoria pública que já
-        fazemos com os custos. Prestação de contas do gasto e da receita, no mesmo lugar.
-      </p>
-    </article>
-
-  </div>
-</section>
-{% endif %}
-
-<!-- ========================== FOUNDED BY =========================== -->
+<!-- ============================== QUEM MANTÉM ============================== -->
 <section class="section container section-narrow" aria-labelledby="founders-heading">
-  <h2 id="founders-heading">Uma iniciativa Expertia × EuMaker</h2>
+  <h2 id="founders-heading">Quem mantém</h2>
   <p class="lead">
     A BNCC API é criada e mantida pela <a href="https://expertia.dev.br" rel="noopener">Expertia</a>
     e pela <a href="https://eumaker.dev" rel="noopener">EuMaker</a>, de
     <a href="https://github.com/eumakerdev" rel="noopener">Fábio Santana</a> — no Brasil,
-    para quem constrói educação no Brasil. Código aberto (MIT), contribuições bem-vindas.
+    para quem constrói educação no Brasil. Código aberto sob licença MIT, contribuições bem-vindas.
   </p>
   <p class="notice">
     Iniciativa <strong>independente e não-oficial</strong>, sem vínculo com o MEC. Os textos de
@@ -566,7 +537,7 @@ API keys self-service.{% endblock %}
   </p>
 </section>
 
-<!-- ============================== FAQ ============================== -->
+<!-- ================================= FAQ ================================= -->
 <section class="section container" id="perguntas-frequentes" aria-labelledby="faq-heading">
   <h2 id="faq-heading">Perguntas frequentes</h2>
   <div class="faq-list">
@@ -596,8 +567,8 @@ API keys self-service.{% endblock %}
     <details class="faq-item">
       <summary>A base de habilidades está completa?</summary>
       <p>
-        Sim: 1.703 habilidades cobrindo Educação Infantil, Ensino Fundamental e Ensino
-        Médio, incluindo as 140 do Complemento de Computação. O snapshot é versionado e a
+        Sim: 1.717 habilidades cobrindo Educação Infantil, Ensino Fundamental e Ensino
+        Médio, incluindo as 141 do Complemento de Computação. O snapshot é versionado e a
         extração é determinística, reproduzível e auditada.
       </p>
     </details>
@@ -609,17 +580,25 @@ API keys self-service.{% endblock %}
         com elegância.
       </p>
     </details>
+    <details class="faq-item">
+      <summary>Qual a cota e o que acontece se eu estourar?</summary>
+      <p>
+        São 60 requisições por minuto nos endpoints determinísticos. Ao estourar, a API
+        responde 429 com o cabeçalho de espera; nada é bloqueado em definitivo. Se o seu
+        caso precisa de mais, abra uma issue no repositório e conversamos.
+      </p>
+    </details>
   </div>
 </section>
 
-<!-- =========================== CTA FINAL =========================== -->
-<section class="section container cta-final" aria-labelledby="cta-heading">
-  <div class="cta-final-inner">
+<!-- ============================== CTA FINAL ============================== -->
+<section class="band band-brand cta-final" aria-labelledby="cta-heading">
+  <div class="container">
     <h2 id="cta-heading">Sua primeira chamada sai em minutos</h2>
     <p class="lead">Conta gratuita, chave na hora e toda a BNCC à disposição do seu produto.</p>
     <p class="cta-row">
       <a class="btn btn-lg" href="/portal/signup">Criar minha chave grátis</a>
-      <a class="btn btn-secondary btn-lg" href="/guia">Ler o guia de início rápido</a>
+      <a class="btn btn-secondary btn-lg" href="/guia">Ler o guia</a>
     </p>
   </div>
 </section>

--- a/app/web/templates/portal/onboarding.html
+++ b/app/web/templates/portal/onboarding.html
@@ -10,7 +10,7 @@
     <p class="onb-progress-label" aria-live="polite">Pergunta {{ step }} de {{ total }}</p>
     <div class="onb-bar" role="progressbar" aria-valuemin="0" aria-valuemax="{{ total }}"
          aria-valuenow="{{ step - 1 }}" aria-label="Progresso do onboarding">
-      <span class="onb-bar-fill" style="width: {{ progress_pct }}%;"></span>
+      <span class="onb-bar-fill" style="--onb-progress: {{ progress_pct / 100 }};"></span>
     </div>
   </div>
 

--- a/app/web/templates/portal/signup.html
+++ b/app/web/templates/portal/signup.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}Criar conta grátis — BNCC API{% endblock %}
-{% block description %}Crie sua conta gratuita na BNCC API: verifique o e-mail, gere uma API key na hora e acesse as 1.703 habilidades da BNCC. Sem cartão, sem fila de aprovação.{% endblock %}
+{% block description %}Crie sua conta gratuita na BNCC API: verifique o e-mail, gere uma API key na hora e acesse as 1.717 habilidades da BNCC. Sem cartão, sem fila de aprovação.{% endblock %}
 
 {% block content %}
 <div class="container section auth-wrap">


### PR DESCRIPTION
Refatoração completa da landing usando a skill [impeccable](https://github.com/pbakaus/impeccable), com o design system inteiro no escopo.

## Direção

A estrutura anterior seguia a sequência do template SaaS saturado: hero dividido → faixa de números → grid de cards com ícone → passos → mais cards → FAQ → CTA. A nova organiza a página pela escada de crenças, uma seção por argumento:

**a base inteira** (barra proporcional real das três etapas) → **como você sabe que o texto está certo** (a auditoria de extração, que estava enterrada num card) → **primeira chamada** → **casos de uso** → **as contas abertas** (transparência e apoio fundidos) → quem mantém → FAQ → CTA.

Estratégia de cor passa de *restrained* para *committed*: o azul da marca carrega bandas inteiras em vez de aparecer só em botão. Identidade preservada — `#1b4dff`, Inter e o logo seguem intactos.

## Correção de dado

A página publicava **números errados**: dizia 1.703 habilidades e 140 de Computação; o snapshot tem **1.717 e 141**. Estava no `h1`, no FAQ, no JSON-LD, na meta description e no signup. Corrigido em todos os lugares.

## Bugs corrigidos no caminho

- **Ícone do menu mobile duplicado** (pré-existente): `hidden` é atributo global de HTML e não alcança elementos SVG, que estão em outro namespace. Os dois ícones apareciam juntos no celular.
- **Colisão de token no admin**: ele usava `var(--surface, #fallback)` contando que `--surface` não existisse. Com o token criado, o par com `var(--text, …)` — ainda indefinido — daria texto escuro sobre fundo escuro no tema escuro. Aliases definidos.
- **Tarja lateral colorida** em `.notice` e `.docs-nav`, banida pelo skill como o tell mais reconhecível de UI gerada por IA.
- **Barra do onboarding animava `width`** (layout thrash); passa a animar `transform`.
- **Animação de entrada gatilhava visibilidade** com `opacity: 0` + `fill-mode: backwards`, o que deixaria o hero em branco em renderizador headless ou snapshot de SEO.
- **Grids de coluna única** usavam `1fr` em vez de `minmax(0, 1fr)`.

## Verificação

| Portão | Resultado |
|---|---|
| pytest (integração + contrato) | 250 passed, 1 skipped |
| ruff · black | limpos |
| detector determinístico impeccable | 0 achados |
| contraste WCAG AA | todos os pares verificados nos dois temas |

Contraste não foi estimado no olho: os valores OKLCH foram convertidos para sRGB e cada par conferido. Isso pegou três problemas antes de virarem código — `ink-subtle` reprovando em 4.23:1 (usado em *placeholder*, que exige 4.5) e dois valores estourando o gamut silenciosamente.

## Ressalvas

- O **admin** foi corrigido por leitura de CSS, não verificado visualmente (exige login).
- **Mobile** foi testado renderizando cópia offline em iframe de 390px, porque o Chrome da máquina de origem não desce de ~504px de viewport pela CLI. Não substitui device real.
- `PRODUCT.md` (novo, na raiz) carrega o contexto estratégico que os comandos de design leem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yPcHkymwpPpvMhtYeHXu2
