### PR TITLE
docs(segurança): registra o 302 do Firebase Hosting para o host .run.app

### DIFF
--- a/docs/seguranca-endurecimento.md
+++ b/docs/seguranca-endurecimento.md
@@ -105,10 +105,28 @@ requisição — mudança de template, rastreada como trabalho futuro.
   headers de segurança valem igualmente lá. O custo é outro: tráfego que escapa do
   cache da CDN é servido (e faturado) pela instância, e o host interno fica descoberto
   para quem o conhece.
-- **Já mitigado:** desde 1.4.0 o app não *entrega* mais esse host — o
-  `CanonicalLocationMiddleware` reescreve a `Location` dos redirects auto-referentes
-  para `SITE_URL`, então um cliente com `follow_redirects` não migra para a origem sem
-  perceber (era o vetor real, achado da auditoria de 2026-07-29).
+- **Já mitigado no que a aplicação controla:** desde 1.4.0 o app não *entrega* mais
+  esse host — o `CanonicalLocationMiddleware` reescreve a `Location` dos redirects
+  auto-referentes para `SITE_URL`, então um cliente com `follow_redirects` não migra
+  para a origem sem perceber (era o vetor real, achado da auditoria de 2026-07-29).
+  Confirmado em produção: `GET https://bncc-api-….run.app/api/v1/habilidades/` →
+  `307 Location: https://bncc.api.br/api/v1/habilidades`.
+- **Resíduo: o próprio Firebase Hosting emite um 302 para o `.run.app`.** Descoberto na
+  revalidação pós-deploy de 2026-07-29. Em caminhos que a borda normaliza — o caso
+  observado é `..%2F..%2F` — o Firebase/Fastly responde **sem encaminhar ao container**:
+
+  ```
+  GET https://bncc.api.br/api/v1/habilidades/..%2F..%2Fetc%2Fpasswd
+  -> 302  Location: https://bncc-api-esjlky3g3a-rj.a.run.app/api/etc/passwd
+  ```
+
+  Que a resposta não vem da aplicação é demonstrável pelos headers: ela chega **sem**
+  `Content-Security-Policy` e **sem** `X-Frame-Options`, que o `SecurityHeadersMiddleware`
+  injeta em *toda* resposta. O mesmo caminho direto na origem devolve `404` **com** os
+  headers presentes. Ou seja, o `CanonicalLocationMiddleware` não tem como interceptá-lo
+  — o request nunca chega ao container. **Não há path traversal**: nenhum arquivo local é
+  alcançado por nenhum dos dois caminhos. O impacto é o mesmo deste item (divulgação do
+  host interno), e o único caminho de correção é o da topologia, descrito abaixo.
 - **Por que não fechar de vez:** restringir o ingress a
   `internal-and-cloud-load-balancing` é incompatível com o modo como o Firebase Hosting
   encaminha para o serviço — é justamente por esse caminho que o container recebe o


### PR DESCRIPTION
Fecha uma lacuna factual no item **3a** de `docs/seguranca-endurecimento.md`,
descoberta na revalidação em produção logo após o deploy da 1.4.0 (#46).

## O que estava incompleto

O item afirmava que, desde a 1.4.0, o host interno do Cloud Run não é mais entregue
em nenhum redirect. Isso é verdade para **o que a aplicação controla** — verificado em
produção:

```
GET https://bncc-api-….run.app/api/v1/habilidades/
-> 307  Location: https://bncc.api.br/api/v1/habilidades
```

Mas não vale para a borda. Em caminhos que o Firebase/Fastly normaliza — o caso
observado é `..%2F..%2F` — a própria CDN responde, **sem encaminhar ao container**:

```
GET https://bncc.api.br/api/v1/habilidades/..%2F..%2Fetc%2Fpasswd
-> 302  Location: https://bncc-api-esjlky3g3a-rj.a.run.app/api/etc/passwd
```

## Como sei que não é a aplicação

Pelos headers. A resposta via CDN chega **sem** `Content-Security-Policy` e **sem**
`X-Frame-Options` — que o `SecurityHeadersMiddleware` injeta em *toda* resposta HTTP.
O mesmo caminho, direto na origem, devolve `404` **com** os dois headers presentes:

| | via CDN (`bncc.api.br`) | direto na origem (`.run.app`) |
|---|---|---|
| status | `302` | `404` |
| `Location` | `https://…run.app/api/etc/passwd` | — |
| `content-security-policy` | **ausente** | presente |
| `x-frame-options` | **ausente** | presente |

Logo o `CanonicalLocationMiddleware` não tem como interceptá-lo: o request nunca chega
ao container. Não há correção possível no código da aplicação.

## O que não muda

**Não há path traversal** — nenhum arquivo local é alcançado por nenhum dos dois
caminhos. O impacto é exatamente o que o item 3a já rastreava (divulgação do host
interno), e o caminho de correção continua sendo o de topologia (LB HTTPS externo +
Cloud CDN, para então restringir o ingress), já descrito ali.

Mudança **somente de documentação** — nenhum código, teste ou contrato tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v94rqkiCU3hMyLktV3Yiz