### PR TITLE
fix(seguranca): resolve 64 alertas de code scanning (log-injection e qualidade)

### DIFF
--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.limiters import ai_limiter, deterministic_limiter
 from app.core.ratelimit import SlidingWindowLimiter
 from app.core.security import decode_access_token, hash_api_key
 from app.db.base import get_session
@@ -29,15 +30,11 @@ from app.db.tables import ApiKey, ApiKeyStatus, DeveloperAccount
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 # --------------------------------------------------------------------------- #
-# Limitadores por bucket (instância única — módulo global)
+# Limitadores por IP (instância única — módulo global)
+#
+# Os limitadores por bucket (deterministic/ai) vivem em app/core/limiters.py
+# (importados acima) — módulo separado para quebrar o ciclo deps ↔ usage_service.
 # --------------------------------------------------------------------------- #
-deterministic_limiter = SlidingWindowLimiter(
-    max_requests=settings.RATE_LIMIT_DETERMINISTIC_PER_MIN,
-    window_seconds=60,
-    burst=settings.RATE_LIMIT_DETERMINISTIC_BURST,
-)
-ai_limiter = SlidingWindowLimiter(max_requests=settings.RATE_LIMIT_AI_PER_MIN, window_seconds=60)
-
 # Limitadores por IP dos endpoints de sessão (login/signup/verify-email não usam
 # API key, então não passam pelos limitadores acima — força bruta e spam de
 # contas ficariam sem nenhuma cota sem isto).

--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -37,8 +37,8 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
         and "text/html" in request.headers.get("accept", "")
     ):
         # 404 amigável para rotas web (navegador); o contrato JSON de /api fica intacto.
-        # Import tardio: evita ciclo errors -> web.router (padrão já usado no repo).
-        from app.web.router import templates
+        # Import tardio: evita acoplar o tratamento de erros ao seam web no import.
+        from app.web.jinja import templates
 
         return templates.TemplateResponse(
             request, "404.html", status_code=exc.status_code, headers=headers

--- a/app/core/limiters.py
+++ b/app/core/limiters.py
@@ -1,0 +1,19 @@
+"""
+Limitadores por bucket das API keys (instância única — módulo global).
+
+Vivem fora de ``app/core/deps.py`` para quebrar o ciclo de importação
+deps ↔ usage_service (ambos precisavam dos limitadores, mas usage_service era
+importado tardiamente por deps). Qualquer módulo importa os limitadores daqui.
+"""
+
+from __future__ import annotations
+
+from app.core.config import settings
+from app.core.ratelimit import SlidingWindowLimiter
+
+deterministic_limiter = SlidingWindowLimiter(
+    max_requests=settings.RATE_LIMIT_DETERMINISTIC_PER_MIN,
+    window_seconds=60,
+    burst=settings.RATE_LIMIT_DETERMINISTIC_BURST,
+)
+ai_limiter = SlidingWindowLimiter(max_requests=settings.RATE_LIMIT_AI_PER_MIN, window_seconds=60)

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -70,15 +70,3 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         except Exception:
             await session.rollback()
             raise
-
-
-async def init_models() -> None:
-    """
-    Cria as tabelas a partir dos metadados (dev/testes).
-    Em produção, as migrações Alembic são a fonte da verdade.
-    """
-    # Importa as tabelas para registrá-las no metadata.
-    from app.db import tables  # noqa: F401
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)

--- a/app/db/setup.py
+++ b/app/db/setup.py
@@ -1,0 +1,21 @@
+"""
+Inicialização do schema (dev/testes).
+
+Em produção, as migrações Alembic são a fonte da verdade. Este módulo vive fora
+de ``app.db.base`` para quebrar o ciclo de importação base ↔ tables: ``tables``
+importa ``Base`` no nível do módulo, e a criação de tabelas precisa conhecer os
+dois — então quem faz a ponte é este módulo, não ``base``.
+"""
+
+from __future__ import annotations
+
+from app.db import tables  # noqa: F401  (registra as tabelas no metadata)
+from app.db.base import Base, engine
+
+
+async def init_models() -> None:
+    """
+    Cria as tabelas a partir dos metadados (dev/testes).
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/main.py
+++ b/app/main.py
@@ -50,7 +50,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Banco da plataforma: em dev criamos as tabelas; em prod, Alembic é a verdade.
     try:
-        from app.db.base import init_models
+        from app.db.setup import init_models
 
         await init_models()
     except Exception as e:  # pragma: no cover - defensivo

--- a/app/models/bncc.py
+++ b/app/models/bncc.py
@@ -16,7 +16,7 @@ import re
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator, validator
+from pydantic import BaseModel, Field, field_validator
 
 # --------------------------------------------------------------------------- #
 # Padrões oficiais de código (FR-002) — três etapas
@@ -320,7 +320,7 @@ class HabilidadeFiltros(BaseModel):
         None, description="Filtrar por eixo do Complemento de Computação (EI/EF)"
     )
 
-    @validator("competencia_geral")
+    @field_validator("competencia_geral")
     def validate_competencia_geral(cls, v):
         """Valida que a competência geral está no range 1-10."""
         if v is not None and (v < 1 or v > 10):

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -105,7 +105,7 @@ def _build_prompt(query: str, contexto: str) -> str:
 def _deterministic_answer(query: str, fontes: list[dict[str, Any]]) -> str:
     """Resumo deterministico das fontes (fallback sem LLM)."""
     linhas = [
-        "Com base nas fontes oficiais da BNCC mais relevantes para a sua " "pergunta, destaco:",
+        "Com base nas fontes oficiais da BNCC mais relevantes para a sua pergunta, destaco:",
         "",
     ]
     for f in fontes[:5]:

--- a/app/services/bncc_service.py
+++ b/app/services/bncc_service.py
@@ -90,7 +90,9 @@ class BNCCDataService:
                 try:
                     return Habilidade(**hab)
                 except Exception as e:  # pragma: no cover - snapshot inconsistente
-                    logger.warning("Habilidade inválida no snapshot (%s): %s", codigo, e)
+                    # repr() neutraliza controle de formatação do input (anti
+                    # log-forging — Princípio V, entrada hostil na fronteira).
+                    logger.warning("Habilidade inválida no snapshot (%s): %s", repr(codigo), e)
                     return None
         return None
 

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -189,7 +189,7 @@ async def record_error(session: AsyncSession, api_key_id: str, bucket: UsageBuck
 
 async def key_usage(session: AsyncSession, api_key_id: str) -> KeyUsageResponse:
     """Métricas de consumo de uma key: minuto (limiters) + dia (DB) + limites."""
-    from app.core.deps import ai_limiter, deterministic_limiter
+    from app.core.limiters import ai_limiter, deterministic_limiter
 
     det_minute = deterministic_limiter.current(f"deterministic:{api_key_id}")
     ai_minute = ai_limiter.current(f"ai:{api_key_id}")

--- a/app/web/admin.py
+++ b/app/web/admin.py
@@ -36,7 +36,7 @@ from app.core.deps import AdminRateLimited, get_http_client
 from app.core.security import create_access_token, decode_access_token
 from app.db.base import async_session_factory
 from app.services import oauth_service
-from app.web.router import templates
+from app.web.jinja import templates
 
 router = APIRouter(include_in_schema=False)
 logger = logging.getLogger("bncc.admin")

--- a/app/web/docs.py
+++ b/app/web/docs.py
@@ -25,7 +25,7 @@ from fastapi.responses import HTMLResponse
 
 from app.api import versions as vreg
 from app.api.openapi import release_manifest
-from app.web.router import templates
+from app.web.jinja import templates
 
 router = APIRouter()
 

--- a/app/web/jinja.py
+++ b/app/web/jinja.py
@@ -1,0 +1,54 @@
+"""
+Ambiente Jinja compartilhado do seam SSR (``app/web``).
+
+Vive fora de ``app/web/router.py`` para quebrar o ciclo de importação
+router → {landing, portal, docs, admin} → router (todas as sub-rotas importam
+``templates``). Sub-rotas e demais consumidores importam daqui; este módulo não
+importa nada de ``app.web`` de volta.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import Request
+from fastapi.templating import Jinja2Templates
+
+from app.core.config import settings
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def _seo_context(request: Request) -> dict[str, str]:
+    """Injeta `site_url`/`current_path` em todos os templates SSR.
+
+    `site_url` prefere `settings.SITE_URL` (determinístico, domínio primário) e só
+    cai para `request.base_url` quando não configurado (dev). Assim canonical/OG/
+    sitemap nunca vazam a URL interna do Cloud Run quando servido atrás do Firebase
+    Hosting (que entrega o `Host` do `.run.app` ao container)."""
+    base = (settings.SITE_URL or str(request.base_url)).rstrip("/")
+    return {"site_url": base, "current_path": request.url.path}
+
+
+def _brl(value: object) -> str:
+    """Filtro Jinja: formata um número como moeda pt-BR (R$ 1.234,56)."""
+    try:
+        n = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return ""
+    formatted = f"{n:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+    return f"R$ {formatted}"
+
+
+def _milhar(value: object) -> str:
+    """Filtro Jinja: agrupa milhar no padrão pt-BR (2500 → '2.500')."""
+    try:
+        n = int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return ""
+    return f"{n:,}".replace(",", ".")
+
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR), context_processors=[_seo_context])
+templates.env.filters["brl"] = _brl
+templates.env.filters["milhar"] = _milhar

--- a/app/web/landing.py
+++ b/app/web/landing.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse
 
 from app.core.config import settings
-from app.web.router import templates
+from app.web.jinja import templates
 
 router = APIRouter()
 logger = logging.getLogger("bncc.landing")

--- a/app/web/portal.py
+++ b/app/web/portal.py
@@ -40,7 +40,7 @@ from app.services import (
     usage_service,
 )
 from app.web.charts import build_usage_chart
-from app.web.router import templates
+from app.web.jinja import templates
 
 router = APIRouter()
 logger = logging.getLogger("bncc.oauth")
@@ -253,13 +253,15 @@ async def oauth_callback(
                 expires_minutes=settings.SESSION_EXPIRE_MINUTES,
             )
     except oauth_service.OAuthError:
-        logger.warning("Login social falhou (provider=%s)", provider)
+        # provider já passou pelo whitelist acima; repr() é defesa em profundidade
+        # contra forjação de log (Princípio V).
+        logger.warning("Login social falhou (provider=%s)", repr(provider))
         return _login_redirect_with_error(_OAUTH_FAILED_MSG)
     except Exception:
-        logger.exception("Erro inesperado no callback OAuth (provider=%s)", provider)
+        logger.exception("Erro inesperado no callback OAuth (provider=%s)", repr(provider))
         return _login_redirect_with_error(_OAUTH_FAILED_MSG)
 
-    logger.info("Login social concluído (provider=%s)", provider)
+    logger.info("Login social concluído (provider=%s)", repr(provider))
     response = RedirectResponse(url="/portal/dashboard", status_code=status.HTTP_303_SEE_OTHER)
     # `_set_session` sobrescreve `__session` (que carregava o state) com a sessão real.
     _set_session(response, token)
@@ -438,7 +440,8 @@ async def dashboard_revoke_key(request: Request, key_id: str):
         try:
             await apikey_service.revoke(session, account.id, key_id)
         except Exception:
-            pass
+            # Erro tratado deve ser logado (Princípio VI); repr() evita forjação.
+            logger.warning("Falha ao revogar a API key (key_id=%s)", repr(key_id))
     return RedirectResponse(url="/portal/dashboard", status_code=status.HTTP_303_SEE_OTHER)
 
 

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -2,54 +2,16 @@
 Agregador de rotas server-rendered (SSR): landing, portal, docs.
 
 Este módulo é o **seam compartilhado**. Cada história (US2 portal, US3 docs,
-US5 landing) contribui um sub-router incluído aqui.
+US5 landing) contribui um sub-router incluído aqui. O ambiente Jinja compartilhado
+vive em `app.web.jinja` — fora daqui — para quebrar o ciclo de importação
+router ↔ sub-rotas (todas importam ``templates``).
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from fastapi import APIRouter, Request
-from fastapi.templating import Jinja2Templates
+from fastapi import APIRouter
 
 from app.core.config import settings
-
-TEMPLATES_DIR = Path(__file__).parent / "templates"
-
-
-def _seo_context(request: Request) -> dict[str, str]:
-    """Injeta `site_url`/`current_path` em todos os templates SSR.
-
-    `site_url` prefere `settings.SITE_URL` (determinístico, domínio primário) e só
-    cai para `request.base_url` quando não configurado (dev). Assim canonical/OG/
-    sitemap nunca vazam a URL interna do Cloud Run quando servido atrás do Firebase
-    Hosting (que entrega o `Host` do `.run.app` ao container)."""
-    base = (settings.SITE_URL or str(request.base_url)).rstrip("/")
-    return {"site_url": base, "current_path": request.url.path}
-
-
-def _brl(value: object) -> str:
-    """Filtro Jinja: formata um número como moeda pt-BR (R$ 1.234,56)."""
-    try:
-        n = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return ""
-    formatted = f"{n:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
-    return f"R$ {formatted}"
-
-
-def _milhar(value: object) -> str:
-    """Filtro Jinja: agrupa milhar no padrão pt-BR (2500 → '2.500')."""
-    try:
-        n = int(value)  # type: ignore[call-overload]
-    except (TypeError, ValueError):
-        return ""
-    return f"{n:,}".replace(",", ".")
-
-
-templates = Jinja2Templates(directory=str(TEMPLATES_DIR), context_processors=[_seo_context])
-templates.env.filters["brl"] = _brl
-templates.env.filters["milhar"] = _milhar
 
 web_router = APIRouter()
 
@@ -61,18 +23,21 @@ def include_web_routers() -> None:
 
         web_router.include_router(landing_router)
     except ImportError:
+        # Landing ausente (história não construída) — seam segue sem a rota.
         pass
     try:
         from app.web.portal import router as portal_router
 
         web_router.include_router(portal_router, prefix="/portal")
     except ImportError:
+        # Portal ausente (história não construída) — seam segue sem a rota.
         pass
     try:
         from app.web.docs import router as docs_router
 
         web_router.include_router(docs_router)
     except ImportError:
+        # Docs ausentes (história não construída) — seam segue sem a rota.
         pass
     # Fronteira 1 (isolamento): o painel de admin só é MONTADO quando habilitado.
     # No deploy público de produção `admin_enabled` é False → não há rota `/admin`
@@ -84,6 +49,7 @@ def include_web_routers() -> None:
 
             web_router.include_router(admin_router, prefix="/admin")
         except ImportError:
+            # Admin ausente/desabilitado — seam segue sem a rota.
             pass
 
 

--- a/run.py
+++ b/run.py
@@ -3,7 +3,6 @@
 Script para executar a BNCC API
 """
 
-import os
 import sys
 import argparse
 import subprocess
@@ -44,15 +43,15 @@ def setup_environment():
     # Create data directory
     data_dir = Path("./data")
     data_dir.mkdir(exist_ok=True)
-    
+
     # Copy .env.example to .env if it doesn't exist
     env_file = Path(".env")
     env_example = Path(".env.example")
-    
+
     if not env_file.exists() and env_example.exists():
         env_file.write_text(env_example.read_text())
         logger.info("Created .env file from .env.example")
-    
+
     return True
 
 
@@ -61,18 +60,18 @@ def extract_sample_data():
     try:
         logger.info("Extracting sample BNCC data...")
         result = subprocess.run([
-            sys.executable, "scripts/extract_bncc_data.py", 
+            sys.executable, "scripts/extract_bncc_data.py",
             "--output", "./data/bncc_completa.json",
             "--validate"
         ], capture_output=True, text=True)
-        
+
         if result.returncode != 0:
             logger.error(f"Data extraction failed: {result.stderr}")
             return False
-        
+
         logger.info("Sample data extracted successfully")
         return True
-        
+
     except Exception as e:
         logger.error(f"Error extracting data: {e}")
         return False
@@ -85,14 +84,14 @@ def generate_embeddings():
         result = subprocess.run([
             sys.executable, "scripts/generate_embeddings.py"
         ], capture_output=True, text=True)
-        
+
         if result.returncode != 0:
             logger.error(f"Embedding generation failed: {result.stderr}")
             return False
-        
+
         logger.info("Embeddings generated successfully")
         return True
-        
+
     except Exception as e:
         logger.error(f"Error generating embeddings: {e}")
         return False
@@ -105,16 +104,16 @@ def run_tests():
         result = subprocess.run([
             sys.executable, "-m", "pytest", "tests/", "-v"
         ], capture_output=True, text=True)
-        
+
         if result.returncode != 0:
             logger.warning("Some tests failed")
             logger.info(result.stdout)
             logger.warning(result.stderr)
         else:
             logger.info("All tests passed")
-        
+
         return result.returncode == 0
-        
+
     except Exception as e:
         logger.error(f"Error running tests: {e}")
         return False
@@ -126,15 +125,15 @@ def start_api(host: str = "0.0.0.0", port: int = 8000, reload: bool = True):
         logger.info(f"Starting BNCC API on {host}:{port}")
         logger.info(f"API Documentation: http://{host}:{port}/docs")
         logger.info(f"ReDoc Documentation: http://{host}:{port}/redoc")
-        
+
         subprocess.run([
-            sys.executable, "-m", "uvicorn", 
+            sys.executable, "-m", "uvicorn",
             "app.main:app",
             "--host", host,
             "--port", str(port),
             "--reload" if reload else "--no-reload"
         ])
-        
+
     except KeyboardInterrupt:
         logger.info("API stopped by user")
     except Exception as e:
@@ -150,23 +149,23 @@ def main():
     parser.add_argument("--setup-only", action="store_true", help="Only setup data and exit")
     parser.add_argument("--test", action="store_true", help="Run tests before starting")
     parser.add_argument("--skip-setup", action="store_true", help="Skip data setup")
-    
+
     args = parser.parse_args()
-    
+
     logger.info("BNCC API Setup and Runner")
     logger.info("=" * 50)
-    
+
     # Check requirements
     if not check_python_version():
         return 1
-    
+
     if not check_dependencies():
         return 1
-    
+
     # Setup environment
     if not setup_environment():
         return 1
-    
+
     # Setup data (unless skipped)
     if not args.skip_setup:
         # Check if data file exists
@@ -176,7 +175,7 @@ def main():
                 return 1
         else:
             logger.info("BNCC data file already exists")
-        
+
         # Generate embeddings if needed
         chromadb_dir = Path("./data/chromadb")
         if not chromadb_dir.exists() or not any(chromadb_dir.iterdir()):
@@ -184,26 +183,26 @@ def main():
                 logger.warning("Failed to generate embeddings, but continuing...")
         else:
             logger.info("ChromaDB embeddings already exist")
-    
+
     # Run tests if requested
     if args.test:
         if not run_tests():
             logger.warning("Tests failed, but continuing...")
-    
+
     # Exit if setup-only
     if args.setup_only:
         logger.info("Setup completed successfully!")
         return 0
-    
+
     # Start the API
     start_api(
         host=args.host,
         port=args.port,
         reload=not args.no_reload
     )
-    
+
     return 0
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/scripts/audit/sources/__init__.py
+++ b/scripts/audit/sources/__init__.py
@@ -47,11 +47,9 @@ class Source(Protocol):
 
     def disponivel(self) -> bool:
         """True se a fonte pode responder consultas (arquivos/cache/rede prontos)."""
-        ...
 
     def fetch(self, codigo: str) -> SourceRecord | None:
         """Retorna a testemunha da fonte para `codigo`, ou None se ausente."""
-        ...
 
 
 def carregar_fontes(

--- a/scripts/extract_bncc_data.py
+++ b/scripts/extract_bncc_data.py
@@ -686,8 +686,11 @@ _CE_FOOTER = re.compile(
     r"ENSINO\s+FUNDAMENTAL$|E SUAS TECNOLOGIAS$|SOCIAIS APLICADAS$",
     re.IGNORECASE,
 )
-_LIG1 = re.compile(r"([a-zá-úâ-ûà-ù0-9])f([il])\s+([a-zá-úâ-ûà-ù])", re.IGNORECASE)
-_LIG2 = re.compile(r"([a-zá-úâ-ûà-ù])-\s*f([il])\s+([a-zá-úâ-ûà-ù])", re.IGNORECASE)
+# Classes de acentos em forma canônica única: `á-ú` ∪ `â-û` ∪ `à-ù` é exatamente
+# o bloco contínuo U+00E0–U+00FB (`à-û`) — ranges sobrepostos reordenados não mudam
+# o conjunto aceito, então a forma canônica preserva o texto extraído (Princípio IV).
+_LIG1 = re.compile(r"([a-zà-û0-9])f([il])\s+([a-zà-û])", re.IGNORECASE)
+_LIG2 = re.compile(r"([a-zà-û])-\s*f([il])\s+([a-zà-û])", re.IGNORECASE)
 
 
 def _fix_ligatures(s: str) -> str:
@@ -697,7 +700,8 @@ def _fix_ligatures(s: str) -> str:
         prev = s
         s = _LIG1.sub(r"\1f\2\3", s)
         s = _LIG2.sub(r"\1f\2\3", s)
-    s = re.sub(r"\bfl\s+([a-zá-úâ-û])", r"fl\1", s, flags=re.IGNORECASE)
+    # `á-ú` ∪ `â-û` é o bloco U+00E1–U+00FB (`á-û`) — forma canônica, mesmo conjunto.
+    s = re.sub(r"\bfl\s+([a-zá-û])", r"fl\1", s, flags=re.IGNORECASE)
     return s
 
 

--- a/scripts/generate_og_image.py
+++ b/scripts/generate_og_image.py
@@ -104,7 +104,6 @@ def build_og_image():
 
     width, height = 1200, 630
     img = Image.new("RGB", (width, height), BG_DARK)
-    draw = ImageDraw.Draw(img)
 
     # Brilho sutil da marca no canto superior direito (grande círculo translúcido).
     glow = Image.new("RGBA", (width, height), (0, 0, 0, 0))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,14 +50,13 @@ def _reset_rate_limiters():
     """Zera os limitadores in-process (globais de módulo) entre testes."""
     from app.core.deps import (
         admin_ip_limiter,
-        ai_limiter,
-        deterministic_limiter,
         forgot_ip_limiter,
         login_ip_limiter,
         oauth_ip_limiter,
         signup_ip_limiter,
         verify_ip_limiter,
     )
+    from app.core.limiters import ai_limiter, deterministic_limiter
 
     deterministic_limiter.reset()
     ai_limiter.reset()

--- a/tests/integration/test_access_flow.py
+++ b/tests/integration/test_access_flow.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 import pytest
 from app.core.deps import (
-    deterministic_limiter,
     rate_limit_deterministic,
     require_api_key,
 )
+from app.core.limiters import deterministic_limiter
 from app.db.tables import ApiKey
 from app.main import app
 from app.services import account_service

--- a/tests/unit/test_bncc_parsing.py
+++ b/tests/unit/test_bncc_parsing.py
@@ -148,3 +148,26 @@ def test_parse_ef_deduplica_codigo():
     result = parse_ef(texto)
     assert len(result) == 1
     assert "Primeira" in result[0]["descricao"]
+
+
+# --------------------------------------------------------------------------- #
+# Regressão (Princípio IV): as classes canônicas à-û/á-û aceitam exatamente os
+# mesmos caracteres que as ranges sobrepostas originais — o texto extraído não
+# pode mudar quando o extrator é editado.
+# --------------------------------------------------------------------------- #
+def test_fix_ligatures_rejunta_ligaduras_quebradas():
+    from scripts.extract_bncc_data import _fix_ligatures
+
+    # Caso do docstring do extrator (corrupção real de ligadura na prosa).
+    assert _fix_ligatures("classifi cá-la") == "classificá-la"
+    assert _fix_ligatures("afi rmou") == "afirmou"
+    # Hífen partido.
+    assert _fix_ligatures("a-fl uxo") == "afluxo"
+    assert _fix_ligatures("in-fl uência") == "influência"
+    # Extremidades do bloco de acentos: à (U+00E0), á (U+00E1), ú (U+00FA), û (U+00FB).
+    assert _fix_ligatures("àfi la") == "àfila"
+    assert _fix_ligatures("afi laû") == "afilaû"
+    assert _fix_ligatures("fl á") == "flá"
+    assert _fix_ligatures("fl û") == "flû"
+    # Texto íntegro não é tocado (sem ligadura quebrada).
+    assert _fix_ligatures("fila afiada") == "fila afiada"

--- a/tests/unit/test_log_sanitization.py
+++ b/tests/unit/test_log_sanitization.py
@@ -1,0 +1,39 @@
+"""
+Regressão de sanitização de logs (Princípio V — entrada hostil na fronteira).
+
+Valores controlados pelo usuário não podem forjar linhas/formatar o log
+(CRLF injection, sequências de controle). Os pontos de log afetados usam
+``repr()``; este teste falha se a sanitização for removida.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from app.services.bncc_service import BNCCDataService
+
+
+@pytest.mark.asyncio
+async def test_log_de_habilidade_invalida_escapa_controle_do_usuario(caplog):
+    """Código com quebra de linha não pode forjar uma segunda linha no log."""
+    # Snapshot corrompido de propósito: o código casa com a entrada do usuário
+    # (após upper) e a validação Pydantic falha, disparando o warning.
+    codigo_malicioso = "EF99XX\n[forjado] INFO: invasao"
+    service = BNCCDataService(
+        {"habilidades": [{"codigo": codigo_malicioso.upper(), "descricao": ""}]}
+    )
+
+    with caplog.at_level(logging.WARNING):
+        resultado = await service.get_habilidade_by_codigo(codigo_malicioso)
+
+    assert resultado is None
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "a habilidade inválida deveria gerar um warning"
+    # O input do usuário não pode aparecer cru na mensagem (CRLF forjaria uma
+    # segunda linha de log); com repr() a quebra vem escapada. O restante do
+    # texto (ex.: ValidationError do Pydantic) é interno, não input do usuário.
+    assert all("EF99XX\n" not in msg for msg in warnings)
+    assert any("EF99XX\\n" in msg for msg in warnings)
+    # Controle positivo: a mensagem ainda identifica o código.
+    assert any("EF99XX" in msg for msg in warnings)


### PR DESCRIPTION
@  
Resolve os 64 alertas abertos do CodeQL (`security-and-quality`, scan de 2026-07-12), conforme Princípio V (segurança por padrão) e III (testes primeiro) da Constituição v1.1.0.

**Correções no código (36 alertas):**
- **log-injection (error)** — `repr()` em valores do usuário nos logs (`bncc_service`, callback OAuth) + teste de regressão (`tests/unit/test_log_sanitization.py`)
- **overly-large-range no extrator** — classes de regex canônicas (`[a-zà-û]`, `[a-zá-û]`); equivalência provada por exaustão de classes + fuzz de 5.000 casos; snapshot versionado intacto (Princípio IV) + teste unitário pinado
- **cyclic-import** — `app/web/jinja.py`, `app/core/limiters.py` e `app/db/setup.py` quebram os ciclos router↔sub-rotas, deps↔usage_service e base↔tables
- **empty-except** — comentários justificados no seam do router; revoke de API key agora loga a falha (Princípio VI)
- **limpezas** — `sys.exit`/import morto (run.py), atribuição morta (`generate_og_image`), concatenação implícita (`ai_service`), `@field_validator` (Pydantic v2), `...` mortos em Protocol

**Dispensados com justificativa no GitHub (28):** 24 convenções Alembic (`revision`/`down_revision`/...), SHA-256 de API key (falso positivo — senhas usam Argon2), import de efeito colateral (`env.py`), 2 estales (cache de transparência).

**Portões:** pytest verde (cobertura 89,6% ≥ 80%), ruff/black/pre-commit limpos, mypy sem regressões (mesmos 7 erros pré-existentes do HEAD).

Os 36 alertas restantes fecham automaticamente no scan do CodeQL disparado pelo merge em `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@