### PR TITLE
chore(deps): destrava pandas 3.0.5 com numpy 1.26.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,10 @@
 # Extração determinística da BNCC a partir dos PDFs oficiais (scripts/).
 # Ver CLAUDE.md: pdfplumber isola colunas; pikepdf normaliza o page tree
 # comprimido do documento completo da Educação Infantil.
-pandas==2.1.4
+# pandas 3.x (Copy-on-Write por padrão) — validado contra os PDFs oficiais:
+# a extração + reconciliação regeneram `data/bncc_v1.json` byte-idêntico
+# (Princípio IV). Requer numpy>=1.26 (pin em requirements.txt).
+pandas==3.0.5
 beautifulsoup4==4.15.0
 lxml==6.1.1
 pdfplumber==0.11.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,9 @@ google-generativeai==0.8.6
 # ndarray; `vector_store` chama `.tolist()` nos embeddings). O teto `<2` vinha do
 # langchain 0.1.0; com ele fora da stack o pino 1.x é apenas conservador — o bump
 # para numpy 2.x fica liberado para o Dependabot propor, validado pelos portões de CI.
-numpy==1.24.3
+# 1.26.4 (último da linha 1.x) destrava pandas 3.x nos scripts de extração (dev),
+# que exige numpy>=1.26.
+numpy==1.26.4
 requests==2.34.2
 
 # Produção


### PR DESCRIPTION
## Contexto

O PR #52 do Dependabot (`pandas 2.1.4 → 3.0.5`) falha na instalação do CI: pandas 3.x exige `numpy>=1.26`, mas `requirements.txt` pinava `numpy==1.24.3` — um pino conservador herdado da era LangChain. A emenda v1.1.0 da Constituição removeu o LangChain da stack e deixou o bump de numpy/pandas liberado para validação pelos portões de CI (follow-up TODO do SYNC IMPACT REPORT).

Este PR faz o bump acoplado e **substitui** o PR #52.

## Mudanças

- `requirements.txt`: `numpy==1.24.3` → `numpy==1.26.4` (último da linha 1.x; o bump para numpy 2.x continua liberado para o Dependabot propor em separado)
- `requirements-dev.txt`: `pandas==2.1.4` → `pandas==3.0.5` (Copy-on-Write por padrão)

## Validação de fidelidade (Princípio IV)

Os PDFs oficiais de EF/EM foram restaurados localmente a partir do backup e conferidos contra `checksum_fontes` do snapshot versionado (SHA-256 idênticos). Com `numpy 1.26.4 + pandas 3.0.5`:

1. `scripts/extract_bncc_data.py` — 1716 habilidades extraídas das 3 etapas + Computação
2. `scripts/reconcile_bncc_descriptions.py` — 176 correções aplicadas, 8 inseridas (incl. `EF05CO11`), 3 removidas (`EM13MAT409`/`EM13MAT512` não homologadas) → 1721 habilidades
3. Snapshot regenerado **byte-idêntico** ao versionado (só `data_publicacao` difere, comportamento esperado do pipeline)

O Copy-on-Write do pandas 3.0 não altera o dado oficial. Suíte local verde com cobertura de 89.6%.

## Notas

- pandas é dependência **dev-only** (stack de extração de PDF; nada em `app/` a importa) — não entra na imagem de produção.
- CI roda os gates completos da Constituição: testes + cobertura ≥80%, ruff/black, docker-build (que indexa embeddings de verdade com a stack de IA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)