### PR TITLE
fix: exemplo de curl da landing deixa de expor o host interno do Cloud Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ versão maior (Princípio I da [Constituição](.specify/memory/constitution.md)
 
 ## [Não lançado]
 
+### Corrigido — exemplo de `curl` da landing deixou de expor o host interno do Cloud Run
+
+O bloco "Da conta à primeira chamada" montava a URL do exemplo com `request.base_url` em
+vez do `site_url` já injetado pelo contexto Jinja (`app/web/jinja.py::_seo_context`) —
+atrás do Firebase Hosting esse é sempre o `Host` **interno** `.run.app` (o Firebase não
+repassa o domínio público ao container), então um visitante real de `bncc.api.br` via o
+exemplo de `curl` apontando para `bncc-api-….run.app`. Era o único ponto do template com
+esse padrão; canonical, Open Graph, JSON-LD, sitemap e robots já usavam `site_url`
+corretamente (mesma família do fix de redirects da 1.4.0). Sem impacto em `/api/v1`.
+
 ### Corrigido — a transparência de custos voltou a se atualizar sozinha
 
 A seção pública publicava **R$ 103,78** desde 12/07 — um valor semeado à mão, enquanto o

--- a/app/web/templates/landing.html
+++ b/app/web/templates/landing.html
@@ -222,7 +222,7 @@ semântica com IA e API keys self-service. Grátis e open-source.{% endblock %}
     </li>
   </ol>
   <pre class="curl-block"><code>curl -H <span class="tv">"Authorization: Bearer SUA_API_KEY"</span> \
-  "{{ (request.base_url|string).rstrip('/') }}/api/v1/habilidades?etapa=ensino_fundamental&amp;ano=5"</code></pre>
+  "{{ site_url }}/api/v1/habilidades?etapa=ensino_fundamental&amp;ano=5"</code></pre>
 </section>
 
 <!-- ============================ CASOS DE USO ============================

--- a/tests/integration/test_landing.py
+++ b/tests/integration/test_landing.py
@@ -97,6 +97,8 @@ def test_site_url_overrides_canonical_and_sitemap(client, monkeypatch):
     body = client.get("/").text
     assert 'rel="canonical" href="https://bncc.api.br/"' in body
     assert 'property="og:url" content="https://bncc.api.br/"' in body
+    assert "https://bncc.api.br/api/v1/habilidades" in body
+    assert "run.app" not in body
 
     sitemap = client.get("/sitemap.xml").text
     assert "<loc>https://bncc.api.br/</loc>" in sitemap


### PR DESCRIPTION
## Summary
- O bloco "Da conta à primeira chamada" na landing montava o exemplo de `curl` com `request.base_url`, que atrás do Firebase Hosting é sempre o `Host` interno `.run.app` — um visitante real de `bncc.api.br` via o exemplo apontando para `bncc-api-….run.app`.
- Troca por `site_url` (já injetado por `_seo_context()` e usado em canonical/OG/JSON-LD/sitemap/robots — mesma família do fix de redirects da 1.4.0).
- Sem impacto em `/api/v1`: nenhum endpoint, campo ou contrato muda; é só o texto de um snippet de exemplo.

## Test plan
- [x] `pytest tests/integration/test_landing.py -v` (20 passed, incluindo nova asserção `run.app not in body`)
- [x] `ruff check` / `black --check` nos arquivos tocados
- [ ] Conferir visualmente em produção pós-deploy que o bloco de `curl` mostra `bncc.api.br`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01119JEkNskb2Dx9zp7hb5Lx