### PR TITLE
fix: local-admin ignora GOOGLE_APPLICATION_CREDENTIALS ao subir o proxy

### DIFF
--- a/deploy/admin/local-admin.ps1
+++ b/deploy/admin/local-admin.ps1
@@ -66,6 +66,17 @@ function Ensure-Proxy {
 function Do-Start {
   if (-not (Test-Path $VenvPy)) { throw "venv nao encontrado em $VenvPy - crie o ambiente do projeto primeiro." }
   if (Get-PortPid $Port) { Warn "Ja ha algo na porta $Port (app). Rode 'stop' antes ou use outra -Port."; return }
+
+  # O cloud-sql-proxy (Go) da precedencia a GOOGLE_APPLICATION_CREDENTIALS sobre a ADC do
+  # gcloud. Se essa env var estiver setada no seu perfil (ex.: aponta pra uma service account
+  # de outro projeto/cliente), o proxy autentica com ela e falha com "Cloud SQL Admin API ...
+  # SERVICE_DISABLED" no projeto errado - erro confuso, parece problema no GCP mas e so a
+  # credencial errada sendo escolhida. Forcamos o uso da ADC do usuario (fabio@expertia.dev.br).
+  if ($env:GOOGLE_APPLICATION_CREDENTIALS) {
+    Warn "Ignorando GOOGLE_APPLICATION_CREDENTIALS ($($env:GOOGLE_APPLICATION_CREDENTIALS)) - usando ADC do gcloud"
+    Remove-Item Env:\GOOGLE_APPLICATION_CREDENTIALS -ErrorAction SilentlyContinue
+  }
+
   Ensure-Proxy
   New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 


### PR DESCRIPTION
## Problema

O `cloud-sql-proxy` (Go) dá precedência a `GOOGLE_APPLICATION_CREDENTIALS` sobre a ADC do gcloud. Com essa variável setada no perfil apontando para uma service account de **outro projeto**, o proxy autentica com a credencial errada e falha com:

```
Cloud SQL Admin API ... SERVICE_DISABLED
```

O erro aparenta ser problema de configuração do GCP (API desabilitada no projeto), quando na verdade é apenas a credencial errada sendo escolhida — diagnóstico caro justamente por apontar para o lugar errado.

## Mudança

`Do-Start` limpa a variável do ambiente **do processo** (não do perfil do usuário) antes de `Ensure-Proxy`, avisando qual valor foi ignorado, para que o proxy use a ADC do usuário.

## Escopo e riscos

- Afeta apenas `deploy/admin/local-admin.ps1` — ferramenta de administração **local**; nenhum caminho de runtime da API é tocado.
- `Remove-Item Env:\...` altera só o ambiente do processo PowerShell corrente; o perfil do usuário permanece intacto.
- ASCII-only, conforme a convenção declarada no cabeçalho do script (PowerShell 5.1 quebra o parser com UTF-8 com BOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5mrJpdwsAh6SecB8e8Czj